### PR TITLE
Enable tool tagging

### DIFF
--- a/src/Json/Factory/ToolFactory.php
+++ b/src/Json/Factory/ToolFactory.php
@@ -14,7 +14,14 @@ final class ToolFactory
     {
         Assert::requireFields(['name', 'summary', 'website', 'command', 'test'], $tool, 'tool');
 
-        return new Tool($tool['name'], $tool['summary'], $tool['website'], self::importCommand($tool), new TestCommand($tool['test'], $tool['name']));
+        return new Tool(
+            $tool['name'],
+            $tool['summary'],
+            $tool['website'],
+            $tool['tags'] ?? [],
+            self::importCommand($tool),
+            new TestCommand($tool['test'], $tool['name'])
+        );
     }
 
     private static function importCommand(array $tool): Command

--- a/src/Json/JsonTools.php
+++ b/src/Json/JsonTools.php
@@ -60,6 +60,7 @@ final class JsonTools implements Tools
                 'composer',
                 'Dependency Manager for PHP',
                 'https://getcomposer.org/',
+                [],
                 new ShCommand('composer self-update'),
                 new TestCommand('composer list', 'composer')
             ),
@@ -67,6 +68,7 @@ final class JsonTools implements Tools
                 'composer-bin-plugin',
                 'Composer plugin to install bin vendors in isolated locations',
                 'https://github.com/bamarni/composer-bin-plugin',
+                [],
                 new ShCommand('composer global require bamarni/composer-bin-plugin'),
                 new TestCommand('composer global show bamarni/composer-bin-plugin', 'composer-bin-plugin')
             ),
@@ -74,6 +76,7 @@ final class JsonTools implements Tools
                 'box',
                 'An application for building and managing Phars',
                 'https://box-project.github.io/box2/',
+                [],
                 new ShCommand('curl -Ls https://box-project.github.io/box2/installer.php | php && mv box.phar /usr/local/bin/box && chmod +x /usr/local/bin/box'),
                 new TestCommand('box list', 'box')
             ),

--- a/src/Tool/Tool.php
+++ b/src/Tool/Tool.php
@@ -9,12 +9,16 @@ class Tool
     private $website;
     private $command;
     private $testCommand;
+    private $tags;
 
-    public function __construct(string $name, string $summary, string $website, Command $command, Command $testCommand)
+    public function __construct(string $name, string $summary, string $website, array $tags, Command $command, Command $testCommand)
     {
         $this->name = $name;
         $this->summary = $summary;
         $this->website = $website;
+        $this->tags = \array_map(function (string $tag) {
+            return $tag;
+        }, $tags);
         $this->command = $command;
         $this->testCommand = $testCommand;
     }
@@ -42,5 +46,13 @@ class Tool
     public function testCommand(): Command
     {
         return $this->testCommand;
+    }
+
+    /**
+     * @return array|string[]
+     */
+    public function tags(): array
+    {
+        return $this->tags;
     }
 }

--- a/tests/Json/Factory/ToolFactoryTest.php
+++ b/tests/Json/Factory/ToolFactoryTest.php
@@ -29,11 +29,13 @@ class ToolFactoryTest extends TestCase
                 ]
             ],
             'test' => '/usr/bin/true',
+            'tags' => ['qa', 'static-analysis'],
         ]);
 
         $this->assertSame('phpstan', $tool->name());
         $this->assertSame('Static analysis tool', $tool->summary());
         $this->assertSame('https://github.com/phpstan/phpstan', $tool->website());
+        $this->assertSame(['qa', 'static-analysis'], $tool->tags());
         $this->assertInstanceOf(Command::class, $tool->command());
         $this->assertInstanceOf(TestCommand::class, $tool->testCommand());
     }

--- a/tests/Tool/ToolTest.php
+++ b/tests/Tool/ToolTest.php
@@ -14,11 +14,12 @@ class ToolTest extends TestCase
         $command = $this->prophesize(Command::class)->reveal();
         $testCommand = $this->prophesize(Command::class)->reveal();
 
-        $tool = new Tool('phpstan', 'Static analysis tool', 'https://github.com/phpstan/phpstan', $command, $testCommand);
+        $tool = new Tool('phpstan', 'Static analysis tool', 'https://github.com/phpstan/phpstan', ['qa', 'static-analysis'], $command, $testCommand);
 
         $this->assertSame('phpstan', $tool->name());
         $this->assertSame('Static analysis tool', $tool->summary());
         $this->assertSame('https://github.com/phpstan/phpstan', $tool->website());
+        $this->assertSame(['qa', 'static-analysis'], $tool->tags());
         $this->assertSame($command, $tool->command());
         $this->assertSame($testCommand, $tool->testCommand());
     }


### PR DESCRIPTION
Planned use cases:
* to filter out essential tools to be installed first (install composer before it's used to install other tools)
* to filter out tools not available on the given platform (based on i.e. php version)
* to filter out broken tools
* to allow for selective installation of tools