### PR TITLE
Move php-assumptions to its own namespace

### DIFF
--- a/resources/tools.json
+++ b/resources/tools.json
@@ -255,10 +255,11 @@
       "command": {
         "composer-bin-plugin": {
           "package": "rskuipers/php-assumptions",
-          "namespace": "tools"
+          "namespace": "php-assumptions"
         }
       },
-      "test": "phpa --version"
+      "test": "phpa --version",
+      "tags": ["not-maintained"]
     },
     {
       "name": "phpca",


### PR DESCRIPTION
It is lagging behind with nikic/php-parser. Seems that the project is no longer actively maintained: https://github.com/rskuipers/php-assumptions/issues/30#issuecomment-443622488

<!--
Please read the CONTRIBUTING.md to learn about contributing to this project.

Please also note that this project is released with a Contributor Code of Conduct.
By participating in this project you agree to abide by its terms.
The Code of Conduct can be found in CODE_OF_CONDUCT.md.
-->

