### PR TITLE
Install phpunit 7.x when on PHP 7.1

### DIFF
--- a/resources/tools.json
+++ b/resources/tools.json
@@ -563,9 +563,8 @@
       "summary": "The PHP testing framework",
       "website": "https://phpunit.de/",
       "command": {
-        "phar-download": {
-          "phar": "https://phar.phpunit.de/phpunit.phar",
-          "bin": "%target-dir%/phpunit"
+        "sh": {
+            "command": "[[ \"1\" == $(php -r 'echo version_compare(PHP_VERSION, \"7.2.0\", \">=\");') ]] && (curl -Ls https://phar.phpunit.de/phpunit.phar > %target-dir%/phpunit && chmod +x %target-dir%/phpunit) || (curl -Ls https://phar.phpunit.de/phpunit-7.phar > %target-dir%/phpunit && chmod +x %target-dir%/phpunit)"
         }
       },
       "test": "phpunit --version",


### PR DESCRIPTION
PHPUnit 8 doesn't support PHP 7.1. As long as we support PHP 7.1 there needs to be a different file downloaded, depending on PHP version used. 

I used the `sh` method to script the installation. I'd like to avoid introducing support for any kind of conditional commands until it's needed in more than one case.