### PR TITLE
Tools update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,7 @@ tools/php-cs-fixer:
 	curl -Ls http://cs.sensiolabs.org/download/php-cs-fixer-v2.phar -o tools/php-cs-fixer && chmod +x tools/php-cs-fixer
 
 tools/deptrac:
-	curl -Ls https://github.com/sensiolabs-de/deptrac/releases/download/0.3.0/deptrac.phar -o tools/deptrac && chmod +x tools/deptrac
+	curl -Ls https://github.com/sensiolabs-de/deptrac/releases/download/0.4.0/deptrac.phar -o tools/deptrac && chmod +x tools/deptrac
 
 tools/infection: tools/infection.pubkey
 	curl -Ls https://github.com/infection/infection/releases/download/0.10.6/infection.phar -o tools/infection && chmod +x tools/infection
@@ -139,4 +139,4 @@ tools/infection.pubkey:
 	curl -Ls https://github.com/infection/infection/releases/download/0.10.6/infection.phar.pubkey -o tools/infection.pubkey
 
 tools/box:
-	curl -Ls https://github.com/humbug/box/releases/download/3.1.3/box.phar -o tools/box && chmod +x tools/box
+	curl -Ls https://github.com/humbug/box/releases/download/3.4.0/box.phar -o tools/box && chmod +x tools/box

--- a/bin/devkit.php
+++ b/bin/devkit.php
@@ -141,14 +141,16 @@ CMD;
                     $project = preg_replace('@https://[^/]*/([^/]*/[^/]*).*@', '$1', $phar);
 
                     return strtr(
-                        '-e "s@\"phar\": \"\([^\"]*%PROJECT%[^\"]*\)\"@\"phar\": \"%PHAR%\"@"',
+                        '-e "s@\"phar\": \"([^\"]*%PROJECT%[^\"]*)\"@\"phar\": \"%PHAR%\"@g"'.
+                        ' '.
+                        '-e "s@\"url\": \"([^\"]*%PROJECT%[^\"]*\.phar(\.asc|\.pubkey))\"@\"url\": \"%PHAR%\\2\"@g"',
                         ['%PROJECT%' => $project, '%PHAR%' => $phar]
                     );
                 },
                 $phars
             ));
 
-            return new ShCommand(sprintf('sed -i.bak %s %s', $replacements, $jsonPath));
+            return new ShCommand(sprintf('sed -i.bak -E %s %s', $replacements, $jsonPath));
         }
     }
 );

--- a/resources/tools.json
+++ b/resources/tools.json
@@ -161,7 +161,7 @@
       "website": "https://github.com/phan/phan",
       "command": {
         "phar-download": {
-          "phar": "https://github.com/phan/phan/releases/download/1.2.3/phan.phar",
+          "phar": "https://github.com/phan/phan/releases/download/1.2.4/phan.phar",
           "bin": "%target-dir%/phan"
         }
       },
@@ -589,11 +589,11 @@
       "website": "https://getpsalm.org/",
       "command": {
         "file-download": {
-          "url": "https://github.com/vimeo/psalm/releases/download/3.0.16/psalm.phar.asc",
+          "url": "https://github.com/vimeo/psalm/releases/download/3.0.17/psalm.phar.asc",
           "file": "%target-dir%/psalm.phar.asc"
         },
         "phar-download": {
-          "phar": "https://github.com/vimeo/psalm/releases/download/3.0.16/psalm.phar",
+          "phar": "https://github.com/vimeo/psalm/releases/download/3.0.17/psalm.phar",
           "bin": "%target-dir%/psalm"
         }
       },


### PR DESCRIPTION
* Update box and deptrac (infection cannot be updated until https://github.com/infection/infection/pull/630 is released)
* Fix devkit to update keys as well as phars
* Update phan (1.2.3 -> 1.2.4)
* Update psalm (3.0.16 -> 3.0.17)