### PR TITLE
Install dephpend from the phar published to github

### DIFF
--- a/resources/tools.json
+++ b/resources/tools.json
@@ -57,7 +57,7 @@
       "website": "https://dephpend.com/",
       "command": {
         "phar-download": {
-          "phar": "https://phar.dephpend.com/dephpend.phar",
+          "phar": "https://github.com/mihaeu/dephpend/releases/download/0.5.0/dephpend.phar",
           "bin": "%target-dir%/dephpend"
         }
       },


### PR DESCRIPTION
phar.dephpend.com seems to be down at the moment.

<!--
Please read the CONTRIBUTING.md to learn about contributing to this project.

Please also note that this project is released with a Contributor Code of Conduct.
By participating in this project you agree to abide by its terms.
The Code of Conduct can be found in CODE_OF_CONDUCT.md.
-->

