### PR TITLE
install latest stable phpunit with simple-phpunit

### DIFF
--- a/resources/tools.json
+++ b/resources/tools.json
@@ -722,7 +722,7 @@
           "command": "simple-phpunit install"
         },
         "sh": {
-          "command": "SYMFONY_PHPUNIT_VERSION=8.2 simple-phpunit install"
+          "command": "SYMFONY_PHPUNIT_VERSION=8.2 sh -c '[ $(echo $(php -r \"echo PHP_VERSION >= \\\"7.2\\\";\")) = 1 ] && simple-phpunit install'"
         }
       },
       "test": "simple-phpunit --version"

--- a/resources/tools.json
+++ b/resources/tools.json
@@ -720,6 +720,9 @@
         },
         "sh": {
           "command": "simple-phpunit install"
+        },
+        "sh": {
+          "command": "SYMFONY_PHPUNIT_VERSION=8.2 simple-phpunit install"
         }
       },
       "test": "simple-phpunit --version"


### PR DESCRIPTION
This makes phpunit-7.x + phpunit-8.x avaialble out-of-the-box for the time being. That is till November 2019 when SF 4.4 is released:  https://github.com/symfony/symfony/pull/32059

I think it's worth to pre-install it here for convenience and general availability while needed.

I'll try to work on a fix before SF 4.4 to allow picking the latest stable (e.g. using `SYMFONY_PHPUNIT_VERSION=@stable` here or as a SF core default), so we dont have to rely on hard coded upper version constraint.