### PR TITLE
Pre-install PHPUnit 8 with simple-phpunit

### DIFF
--- a/resources/tools.json
+++ b/resources/tools.json
@@ -719,7 +719,7 @@
           "links": {"%target-dir%/simple-phpunit": "simple-phpunit"}
         },
         "sh": {
-          "command": "simple-phpunit install && SYMFONY_PHPUNIT_VERSION=8.2 simple-phpunit-install"
+          "command": "simple-phpunit install && SYMFONY_PHPUNIT_VERSION=8.2 simple-phpunit install"
         }
       },
       "test": "simple-phpunit --version",

--- a/resources/tools.json
+++ b/resources/tools.json
@@ -719,10 +719,11 @@
           "links": {"%target-dir%/simple-phpunit": "simple-phpunit"}
         },
         "sh": {
-          "command": "simple-phpunit install"
+          "command": "simple-phpunit install && SYMFONY_PHPUNIT_VERSION=8.2 simple-phpunit-install"
         }
       },
-      "test": "simple-phpunit --version"
+      "test": "simple-phpunit --version",
+      "tags": ["exclude-php:7.1"]
     },
     {
       "name": "testability",


### PR DESCRIPTION
See https://github.com/symfony/symfony/pull/32059#issuecomment-502426561 for relevant info.

`simple-phpunit` will start installing PHPunit 8 (e.g. latest major) by default as of `symfony/phpunit-bridge@4.4`, that's November 2019 :(

It should be used using `SYMFONY_PHPUNIT_VERSION=8.2 simple-phpunit`, but currently you wont benefit from a default installation available on the image :(

Eventually the cycle can start over, if we want to keep installing e.g. 2 latest majors.

(As a side effect simple-phpunit is now excluded on PHP 7.1, personally i'm fine with that)