### PR TITLE
Remove PHP_Testability, DesignPatternDetector

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ test-min: update-min cs deptrac phpunit infection
 
 test-integration: package
 	rm -rf ./build/tools && \
-	  export PATH="$(shell pwd)/build/tools:$(shell pwd)/build/tools/.composer/vendor/bin:$(shell pwd)/build/tools/QualityAnalyzer/bin:$(shell pwd)/build/tools/DesignPatternDetector/bin:$(shell pwd)/build/tools/EasyCodingStandard/bin:$$PATH" && \
+	  export PATH="$(shell pwd)/build/tools:$(shell pwd)/build/tools/.composer/vendor/bin:$(shell pwd)/build/tools/QualityAnalyzer/bin:$(shell pwd)/build/tools/EasyCodingStandard/bin:$$PATH" && \
 	  export COMPOSER_HOME=$(shell pwd)/build/tools/.composer && \
 	  chmod +x build/toolbox.phar && \
 	  mkdir -p ./build/tools && \

--- a/README.md
+++ b/README.md
@@ -73,7 +73,6 @@ It has been extracted as a separate project to make maintenance easier and enabl
 * roave-backward-compatibility-check - [Tool to compare two revisions of a class API to check for BC breaks](https://github.com/Roave/BackwardCompatibilityCheck)
 * security-checker - [Checks composer dependencies for known security vulnerabilities](https://github.com/sensiolabs/security-checker)
 * simple-phpunit - [Provides utilities to report legacy tests and usage of deprecated code](https://symfony.com/doc/current/components/phpunit_bridge.html)
-* testability - [Analyses and reports testability issues of a php codebase](https://github.com/edsonmedina/php_testability)
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ It has been extracted as a separate project to make maintenance easier and enabl
 * dephpend - [Detect flaws in your architecture](https://dephpend.com/)
 * deprecation-detector - [Finds usages of deprecated code](https://github.com/sensiolabs-de/deprecation-detector)
 * deptrac - [Enforces dependency rules between software layers](https://github.com/sensiolabs-de/deptrac)
-* design-pattern - [Detects design patterns](https://github.com/Halleck45/DesignPatternDetector)
 * diffFilter - [Applies QA tools to run on a single pull request](https://github.com/exussum12/coverageChecker)
 * ecs - [Sets up and runs coding standard checks](https://github.com/Symplify/EasyCodingStandard)
 * infection - [AST based PHP Mutation Testing Framework](https://infection.github.io/)
@@ -73,6 +72,11 @@ It has been extracted as a separate project to make maintenance easier and enabl
 * roave-backward-compatibility-check - [Tool to compare two revisions of a class API to check for BC breaks](https://github.com/Roave/BackwardCompatibilityCheck)
 * security-checker - [Checks composer dependencies for known security vulnerabilities](https://github.com/sensiolabs/security-checker)
 * simple-phpunit - [Provides utilities to report legacy tests and usage of deprecated code](https://symfony.com/doc/current/components/phpunit_bridge.html)
+
+### Removed tools
+
+* design-pattern - [Detects design patterns](https://github.com/Halleck45/DesignPatternDetector)
+* testability - [Analyses and reports testability issues of a php codebase](https://github.com/edsonmedina/php_testability)
 
 ## Installation
 

--- a/resources/tools.json
+++ b/resources/tools.json
@@ -724,19 +724,6 @@
       },
       "test": "simple-phpunit --version",
       "tags": ["exclude-php:7.1"]
-    },
-    {
-      "name": "testability",
-      "summary": "Analyses and reports testability issues of a php codebase",
-      "website": "https://github.com/edsonmedina/php_testability",
-      "command": {
-        "composer-bin-plugin": {
-          "package": "edsonmedina/php_testability:dev-master",
-          "namespace": "tools",
-          "links": {"%target-dir%/testability": "testability"}
-        }
-      },
-      "test": "testability --help"
     }
   ]
 }

--- a/resources/tools.json
+++ b/resources/tools.json
@@ -89,18 +89,6 @@
       "tags": ["featured"]
     },
     {
-      "name": "design-pattern",
-      "summary": "Detects design patterns",
-      "website": "https://github.com/Halleck45/DesignPatternDetector",
-      "command": {
-        "composer-install": {
-          "repository": "https://github.com/Halleck45/DesignPatternDetector.git",
-          "target-dir": "%target-dir%/DesignPatternDetector"
-        }
-      },
-      "test": "design-pattern -V"
-    },
-    {
       "name": "diffFilter",
       "summary": "Applies QA tools to run on a single pull request",
       "website": "https://github.com/exussum12/coverageChecker",


### PR DESCRIPTION
fixes #117

For `halleck45/phpmetrics`, it's part of https://github.com/Halleck45/DesignPatternDetector 

Last commit 4 years ago, i'm not sure i should open a PR there :sweat_smile: do we want to keep it?