### PR TITLE
bump simple-phpunit

### DIFF
--- a/resources/tools.json
+++ b/resources/tools.json
@@ -707,7 +707,7 @@
           "links": {"%target-dir%/simple-phpunit": "simple-phpunit"}
         },
         "sh": {
-          "command": "simple-phpunit install && SYMFONY_PHPUNIT_VERSION=8.2 simple-phpunit install"
+          "command": "simple-phpunit install && SYMFONY_PHPUNIT_VERSION=8 simple-phpunit install"
         }
       },
       "test": "simple-phpunit --version",


### PR DESCRIPTION
This installs the latest minor version by default, which changes over time (there should be no sudden BC breaks due semver), it reduces the maintenance on our side for a while.

Im proposing the same change on Symfony's side, as of 4.4: https://github.com/symfony/symfony/pull/33318

