### PR TITLE
Revert "Update tools"

### DIFF
--- a/resources/tools.json
+++ b/resources/tools.json
@@ -676,7 +676,7 @@
       "website": "https://github.com/Roave/BackwardCompatibilityCheck",
       "command": {
         "phar-download": {
-          "phar": "https://github.com/Roave/BackwardCompatibilityCheck/releases/download/4.1.0/roave-backward-compatibility-check.phar",
+          "phar": "https://github.com/Roave/BackwardCompatibilityCheck/releases/download/4.0.0/roave-backward-compatibility-check.phar",
           "bin": "%target-dir%/roave-backward-compatibility-check"
         }
       },


### PR DESCRIPTION
Reverts jakzal/toolbox#144

Downgrades roave-backward-compatibility-check (4.1.0 -> 4.0.0) for now, at least until https://github.com/beberlei/assert/issues/288 is fixed.