### PR TITLE
Add PHP Architecture Tester

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ It has been extracted as a separate project to make maintenance easier and enabl
 * phpDocumentor - [Documentation generator](https://www.phpdoc.org/)
 * phpbench - [PHP Benchmarking framework](https://github.com/phpbench/phpbench)
 * phpa - [Checks for weak assumptions](https://github.com/rskuipers/php-assumptions)
+* phpat - [PHP Architecture Tester](https://github.com/carlosas/phpat)
 * phpca - [Finds usage of non-built-in extensions](https://github.com/wapmorgan/PhpCodeAnalyzer)
 * phpcb - [PHP Code Browser](https://github.com/mayflower/PHP_CodeBrowser)
 * phpcbf - [Automatically corrects coding standard violations](https://github.com/squizlabs/PHP_CodeSniffer)

--- a/resources/tools.json
+++ b/resources/tools.json
@@ -291,6 +291,19 @@
       "test": "phpca -h"
     },
     {
+      "name": "phpat",
+      "summary": "Easy to use architecture testing tool",
+      "website": "https://github.com/carlosas/phpat",
+      "command": {
+        "composer-bin-plugin": {
+          "package": "carlosas/phpat",
+          "namespace": "tools",
+          "links": {"%target-dir%/phpat": "phpat"}
+        }
+      },
+      "test": "phpat"
+    },
+    {
       "name": "phpcb",
       "summary": "PHP Code Browser",
       "website": "https://github.com/mayflower/PHP_CodeBrowser",


### PR DESCRIPTION
PHP Architecture Tester is a static analysis tool to verify architectural requirements.
It provides a natural language abstraction to define your own architectural rules and test them against your software.

There are four groups of supported assertions: Dependency, Inheritance, Composition and Mixin.