### PR TITLE
Lock ecs to 7.3.17 until a stable v8 is released

### DIFF
--- a/resources/tools.json
+++ b/resources/tools.json
@@ -119,12 +119,12 @@
       "website": "https://github.com/Symplify/EasyCodingStandard",
       "command": {
         "composer-bin-plugin": {
-          "package": "symplify/easy-coding-standard-prefixed",
+          "package": "symplify/easy-coding-standard-prefixed:7.3.17",
           "namespace": "tools",
           "links": {"%target-dir%/ecs": "ecs", "%target-dir%/ecs.phar": "ecs.phar"}
         }
       },
-      "test": "ecs -h"
+      "test": "ecs -h", "tags":["ecs"]
     },
     {
       "name": "infection",


### PR DESCRIPTION
Prevents:
```
 [ERROR] Class 'Symplify\PackageBuilder\DependencyInjection\CompilerPass\AutoReturnFactoryCompilerPass' not found
```

re https://github.com/symplify/symplify/issues/1961