### PR TITLE
Psalm plugins revamp + PHPUnit, Symfony

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ It has been extracted as a separate project to make maintenance easier and enabl
 | deprecation-detector | [Finds usages of deprecated code](https://github.com/sensiolabs-de/deprecation-detector) | &#x2705; | &#x2705; | &#x2705; |
 | deptrac | [Enforces dependency rules between software layers](https://github.com/qossmic/deptrac) | &#x2705; | &#x2705; | &#x2705; |
 | diffFilter | [Applies QA tools to run on a single pull request](https://github.com/exussum12/coverageChecker) | &#x2705; | &#x2705; | &#x274C; |
-| doctrine-psalm-plugin | [Stubs to let Psalm understand Doctrine better](https://github.com/weirdan/doctrine-psalm-plugin) | &#x2705; | &#x2705; | &#x2705; |
 | ecs | [Sets up and runs coding standard checks](https://github.com/Symplify/EasyCodingStandard) | &#x2705; | &#x2705; | &#x2705; |
 | infection | [AST based PHP Mutation Testing Framework](https://infection.github.io/) | &#x274C; | &#x2705; | &#x2705; |
 | larastan | [PHPStan extension for Laravel](https://github.com/nunomaduro/larastan) | &#x2705; | &#x2705; | &#x2705; |
@@ -83,6 +82,9 @@ It has been extracted as a separate project to make maintenance easier and enabl
 | phpunit-7 | [The PHP testing framework (7.x version)](https://phpunit.de/) | &#x2705; | &#x2705; | &#x274C; |
 | phpunit-8 | [The PHP testing framework (8.x version)](https://phpunit.de/) | &#x2705; | &#x2705; | &#x2705; |
 | psalm | [Finds errors in PHP applications](https://psalm.dev/) | &#x2705; | &#x2705; | &#x2705; |
+| psalm-plugin-doctrine | [Stubs to let Psalm understand Doctrine better](https://github.com/weirdan/doctrine-psalm-plugin) | &#x2705; | &#x2705; | &#x2705; |
+| psalm-plugin-phpunit | [Psalm plugin for PHPUnit](https://github.com/psalm/psalm-plugin-phpunit) | &#x2705; | &#x2705; | &#x2705; |
+| psalm-plugin-symfony | [Psalm Plugin for Symfony](https://github.com/psalm/psalm-plugin-symfony) | &#x2705; | &#x2705; | &#x2705; |
 | psecio-parse | [Scans code for potential security-related issues](https://github.com/psecio/parse) | &#x2705; | &#x2705; | &#x2705; |
 | rector | [Tool for instant code upgrades and refactoring](https://github.com/rectorphp/rector) | &#x2705; | &#x2705; | &#x2705; |
 | roave-backward-compatibility-check | [Tool to compare two revisions of a class API to check for BC breaks](https://github.com/Roave/BackwardCompatibilityCheck) | &#x274C; | &#x2705; | &#x274C; |

--- a/resources/psalm.json
+++ b/resources/psalm.json
@@ -5,29 +5,58 @@
             "summary": "Finds errors in PHP applications",
             "website": "https://psalm.dev/",
             "command": {
-                "file-download": {
-                    "url": "https://github.com/vimeo/psalm/releases/download/4.6.4/psalm.phar.asc",
-                    "file": "%target-dir%/psalm.phar.asc"
-                },
-                "phar-download": {
-                    "phar": "https://github.com/vimeo/psalm/releases/download/4.6.4/psalm.phar",
-                    "bin": "%target-dir%/psalm"
+                "composer-bin-plugin": {
+                    "package": "vimeo/psalm",
+                    "namespace": "psalm",
+                    "links": {
+                        "%target-dir%/psalm": "psalm",
+                        "%target-dir%/psalm-language-server": "psalm-language-server",
+                        "%target-dir%/psalm-plugin": "psalm-plugin",
+                        "%target-dir%/psalm-refactor": "psalm-refactor",
+                        "%target-dir%/psalter": "psalter"
+                    }
                 }
             },
             "test": "psalm -h",
             "tags": ["featured", "psalm"]
         },
         {
-            "name": "doctrine-psalm-plugin",
+            "name": "psalm-plugin-doctrine",
             "summary": "Stubs to let Psalm understand Doctrine better",
             "website": "https://github.com/weirdan/doctrine-psalm-plugin",
             "command": {
                 "composer-bin-plugin": {
                     "package": "weirdan/doctrine-psalm-plugin",
-                    "namespace": "doctrine-psalm-plugin"
+                    "namespace": "psalm"
                 }
             },
-            "test": "composer global bin doctrine-psalm-plugin show weirdan/doctrine-psalm-plugin",
+            "test": "rm -f composer.json; psalm-plugin show | grep weirdan/doctrine-psalm-plugin",
+            "tags": ["psalm"]
+        },
+        {
+            "name": "psalm-plugin-phpunit",
+            "summary": "Psalm plugin for PHPUnit",
+            "website": "https://github.com/psalm/psalm-plugin-phpunit",
+            "command": {
+                "composer-bin-plugin": {
+                    "package": "psalm/plugin-phpunit",
+                    "namespace": "psalm"
+                }
+            },
+            "test": "rm -f composer.json; psalm-plugin show | grep psalm/plugin-phpunit",
+            "tags": ["psalm"]
+        },
+        {
+            "name": "psalm-plugin-symfony",
+            "summary": "Psalm Plugin for Symfony",
+            "website": "https://github.com/psalm/psalm-plugin-symfony",
+            "command": {
+                "composer-bin-plugin": {
+                    "package": "psalm/plugin-symfony",
+                    "namespace": "psalm"
+                }
+            },
+            "test": "rm -f composer.json; psalm-plugin show | grep psalm/plugin-symfony",
             "tags": ["psalm"]
         }
     ]

--- a/resources/psalm.json
+++ b/resources/psalm.json
@@ -30,7 +30,7 @@
                     "namespace": "psalm"
                 }
             },
-            "test": "rm -f composer.json; psalm-plugin show | grep weirdan/doctrine-psalm-plugin",
+            "test": "cd / && psalm-plugin show | grep weirdan/doctrine-psalm-plugin",
             "tags": ["psalm"]
         },
         {
@@ -43,7 +43,7 @@
                     "namespace": "psalm"
                 }
             },
-            "test": "rm -f composer.json; psalm-plugin show | grep psalm/plugin-phpunit",
+            "test": "cd / && psalm-plugin show | grep psalm/plugin-phpunit",
             "tags": ["psalm"]
         },
         {
@@ -56,7 +56,7 @@
                     "namespace": "psalm"
                 }
             },
-            "test": "rm -f composer.json; psalm-plugin show | grep psalm/plugin-symfony",
+            "test": "cd / && psalm-plugin show | grep psalm/plugin-symfony",
             "tags": ["psalm"]
         }
     ]


### PR DESCRIPTION
1. Psalm moved from PHAR to be installed via Composer (AFAIK, required for the plugins to be found)
2. moved the existing Doctrine plugin to the same namespace, `psalm`
3. added Symfony plugin, #235
4. added PHPUnit plugin, #99 
