### PR TITLE
Update phpat package name

### DIFF
--- a/resources/tools.json
+++ b/resources/tools.json
@@ -297,7 +297,7 @@
       "website": "https://github.com/carlosas/phpat",
       "command": {
         "composer-bin-plugin": {
-          "package": "carlosas/phpat",
+          "package": "phpat/phpat",
           "namespace": "tools",
           "links": {"%target-dir%/phpat": "phpat"}
         }


### PR DESCRIPTION
Hello. I have deprecated https://packagist.org/packages/carlosas/phpat in favor of https://packagist.org/packages/phpat/phpat
The repo remains the same, the only change is the composer package name :)