### PR TITLE
install simple-phpunit v9

### DIFF
--- a/resources/tools.json
+++ b/resources/tools.json
@@ -769,7 +769,7 @@
           "links": {"%target-dir%/simple-phpunit": "simple-phpunit"}
         },
         "sh": {
-          "command": "simple-phpunit install && SYMFONY_PHPUNIT_VERSION=8 simple-phpunit install"
+          "command": "simple-phpunit install && SYMFONY_PHPUNIT_VERSION=9 simple-phpunit install"
         }
       },
       "test": "simple-phpunit --version"


### PR DESCRIPTION
v8 is now the current default in symfony's bridge: https://github.com/symfony/symfony/blob/master/src/Symfony/Bridge/PhpUnit/bin/simple-phpunit.php#L98

v9 is the current stable however