### PR TITLE
Downgrade composer until box can work with composer v2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
                 uses: shivammathur/setup-php@v2
                 with:
                     php-version: "${{ matrix.php }}"
-                    tools: flex
+                    tools: flex, composer:v1
                     ini-values: "phar.readonly=0"
 
             -   if: matrix.deps == 'high'
@@ -64,7 +64,7 @@ jobs:
                 uses: shivammathur/setup-php@v2
                 with:
                     php-version: "${{ matrix.php }}"
-                    tools: flex
+                    tools: flex, composer:v1
                     ini-values: "phar.readonly=0"
 
             -   uses: actions/download-artifact@v1


### PR DESCRIPTION
```
PHP Fatal error:  Class '_HumbugBoxcdca866e7251\Symfony\Component\Console\Application' not found in phar:///home/runner/work/toolbox/toolbox/build/toolbox.phar/src/Cli/Application.php on line 16
12
PHP Stack trace:
13
PHP   1. {main}() /home/runner/work/toolbox/toolbox/build/toolbox.phar:0
14
PHP   2. require() /home/runner/work/toolbox/toolbox/build/toolbox.phar:12
15
PHP   3. spl_autoload_call() phar:///home/runner/work/toolbox/toolbox/build/toolbox.phar/bin/toolbox.php:6
16
PHP   4. Composer\Autoload\ClassLoader->loadClass() phar:///home/runner/work/toolbox/toolbox/build/toolbox.phar/bin/toolbox.php:6
17
PHP   5. Composer\Autoload\includeFile() phar:///home/runner/work/toolbox/toolbox/build/toolbox.phar/vendor/composer/ClassLoader.php:322
18
PHP   6. include() phar:///home/runner/work/toolbox/toolbox/build/toolbox.phar/vendor/composer/ClassLoader.php:444
```

<!--
Please read the CONTRIBUTING.md to learn about contributing to this project.

Please also note that this project is released with a Contributor Code of Conduct.
By participating in this project you agree to abide by its terms.
The Code of Conduct can be found in CODE_OF_CONDUCT.md.
-->

