### PR TITLE
Lock rector to the last known working version

### DIFF
--- a/resources/tools.json
+++ b/resources/tools.json
@@ -726,7 +726,7 @@
       "website": "https://github.com/rectorphp/rector",
       "command": {
         "composer-bin-plugin": {
-          "package": "rector/rector-prefixed",
+          "package": "rector/rector-prefixed:0.8.52",
           "namespace": "rector",
           "links": {"%target-dir%/rector": "rector"}
         }


### PR DESCRIPTION
Until this is fixed upstream: https://github.com/rectorphp/rector/issues/4606#issuecomment-731526772