### PR TITLE
Enable PHP-CS-Fixer on PHP 8

### DIFF
--- a/resources/checkstyle.json
+++ b/resources/checkstyle.json
@@ -25,7 +25,7 @@
                 }
             },
             "test": "php-cs-fixer list",
-            "tags": ["featured", "checkstyle", "exclude-php:8.0"]
+            "tags": ["featured", "checkstyle"]
         },
         {
             "name": "php-formatter",


### PR DESCRIPTION
Composer install on PHP8 is now possible with the release of 2.17
