### PR TITLE
Deptrac has been moved to QOSSMIC

### DIFF
--- a/resources/architecture.json
+++ b/resources/architecture.json
@@ -16,10 +16,10 @@
         {
             "name": "deptrac",
             "summary": "Enforces dependency rules between software layers",
-            "website": "https://github.com/sensiolabs-de/deptrac",
+            "website": "https://github.com/qossmic/deptrac",
             "command": {
                 "phar-download": {
-                    "phar": "https://github.com/sensiolabs-de/deptrac/releases/download/0.10.2/deptrac.phar",
+                    "phar": "https://github.com/qossmic/deptrac/releases/download/0.11.0/deptrac.phar",
                     "bin": "%target-dir%/deptrac"
                 }
             },


### PR DESCRIPTION
The company SensioLabs Deutschland GmbH has been renamed to QOSSMIC GmbH. Therefore the vendor had to be adjusted. But nothing to worry about everything should work as before.

