### PR TITLE
Add support for phive-install.

### DIFF
--- a/resources/pre-installation.json
+++ b/resources/pre-installation.json
@@ -13,6 +13,22 @@
       "tags": ["pre-installation"]
     },
     {
+      "name": "phive",
+      "summary": "PHAR Installation and Verification Environment",
+      "website": "https://phar.io/",
+      "command": {
+        "phar-download": {
+          "phar": "https://phar.io/releases/phive.phar",
+          "bin": "%target-dir%/phive"
+        },
+        "sh": {
+          "command": "phive --home %target-dir%"
+        }
+      },
+      "test": "phive --version",
+      "tags": ["pre-installation"]
+    },
+    {
       "name": "composer-bin-plugin",
       "summary": "Composer plugin to install bin vendors in isolated locations",
       "website": "https://github.com/bamarni/composer-bin-plugin",

--- a/src/Json/Factory/PhiveInstallCommandFactory.php
+++ b/src/Json/Factory/PhiveInstallCommandFactory.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types=1);
+
+namespace Zalas\Toolbox\Json\Factory;
+
+use Zalas\Toolbox\Tool\Command;
+use Zalas\Toolbox\Tool\Command\PhiveInstallCommand;
+
+final class PhiveInstallCommandFactory
+{
+    public static function import(array $command): Command
+    {
+        Assert::requireFields(['alias', 'bin'], $command, 'PhiveInstallCommand');
+
+        return new PhiveInstallCommand($command['alias'], $command['bin'], $command['trust'] ?? false, $command['unsigned'] ?? false);
+    }
+}

--- a/src/Json/Factory/ToolFactory.php
+++ b/src/Json/Factory/ToolFactory.php
@@ -46,6 +46,7 @@ final class ToolFactory
             'file-download' => \sprintf('%s::import', FileDownloadCommandFactory::class),
             'box-build' => \sprintf('%s::import', BoxBuildCommandFactory::class),
             'composer-install' => \sprintf('%s::import', ComposerInstallCommandFactory::class),
+            'phive-install' => \sprintf('%s::import', PhiveInstallCommandFactory::class),
             'composer-global-install' => \sprintf('%s::import', ComposerGlobalInstallCommandFactory::class),
             'composer-bin-plugin' => \sprintf('%s::import', ComposerBinPluginCommandFactory::class),
             'sh' => \sprintf('%s::import', ShCommandFactory::class),

--- a/src/Tool/Command/PhiveInstallCommand.php
+++ b/src/Tool/Command/PhiveInstallCommand.php
@@ -1,0 +1,32 @@
+<?php declare(strict_types=1);
+
+namespace Zalas\Toolbox\Tool\Command;
+
+use Zalas\Toolbox\Tool\Command;
+
+final class PhiveInstallCommand implements Command
+{
+    private $alias;
+    private $bin;
+    private $trust;
+    private $unsigned;
+
+    public function __construct(string $alias, string $bin, bool $trust = true, bool $unsigned = false)
+    {
+        $this->alias = $alias;
+        $this->bin = $bin;
+        $this->trust = $trust;
+        $this->unsigned = $unsigned;
+    }
+
+    public function __toString(): string
+    {
+        return \sprintf(
+            'phive install %s %s %s -t %s',
+            $this->trust ? '--trust-gpg-keys' : '',
+            $this->unsigned ? '--force-accept-unsigned' : '',
+            $this->alias,
+            $this->bin
+        );
+    }
+}

--- a/src/UseCase/InstallTools.php
+++ b/src/UseCase/InstallTools.php
@@ -14,6 +14,7 @@ use Zalas\Toolbox\Tool\Command\FileDownloadCommand;
 use Zalas\Toolbox\Tool\Command\MultiStepCommand;
 use Zalas\Toolbox\Tool\Command\OptimisedComposerBinPluginCommand;
 use Zalas\Toolbox\Tool\Command\PharDownloadCommand;
+use Zalas\Toolbox\Tool\Command\PhiveInstallCommand;
 use Zalas\Toolbox\Tool\Command\ShCommand;
 use Zalas\Toolbox\Tool\Filter;
 use Zalas\Toolbox\Tool\Tool;
@@ -41,6 +42,7 @@ class InstallTools
                 ->merge($commandFilter(ShCommand::class))
                 ->merge($commandFilter(FileDownloadCommand::class))
                 ->merge($commandFilter(PharDownloadCommand::class))
+                ->merge($commandFilter(PhiveInstallCommand::class))
                 ->merge($commandFilter(MultiStepCommand::class))
                 ->merge($this->groupComposerGlobalInstallCommands($commandFilter(ComposerGlobalInstallCommand::class)))
                 ->merge($this->groupComposerBinPluginCommands($commandFilter(ComposerBinPluginCommand::class)))

--- a/tests/Json/Factory/PhiveInstallCommandFactoryTest.php
+++ b/tests/Json/Factory/PhiveInstallCommandFactoryTest.php
@@ -1,0 +1,82 @@
+<?php declare(strict_types=1);
+
+namespace Zalas\Toolbox\Tests\Json\Factory;
+
+use PHPUnit\Framework\TestCase;
+use Zalas\Toolbox\Json\Factory\PhiveInstallCommandFactory;
+use Zalas\Toolbox\Tool\Command\PhiveInstallCommand;
+
+class PhiveInstallCommandFactoryTest extends TestCase
+{
+    private const ALIAS = 'example/foo';
+    private const BIN = '/usr/local/bin/foo';
+
+    public function test_it_creates_a_command()
+    {
+        $command = PhiveInstallCommandFactory::import([
+            'alias' => self::ALIAS,
+            'bin' => self::BIN,
+        ]);
+        
+        $this->assertInstanceOf(PhiveInstallCommand::class, $command);
+    }
+
+    /**
+     * @dataProvider provideRequiredProperties
+     */
+    public function test_it_complains_if_any_of_required_properties_is_missing(string $property)
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $properties = [
+            'alias' => self::ALIAS,
+            'bin' => self::BIN,
+        ];
+
+        unset($properties[$property]);
+
+        PhiveInstallCommandFactory::import($properties);
+    }
+
+    public function test_it_accepts_signed_trusted_phars()
+    {
+        $properties = [
+            'alias' => self::ALIAS,
+            'bin' => self::BIN,
+        ];
+
+        $command = PhiveInstallCommandFactory::import($properties);
+        $this->assertStringNotContainsString('trust', (string)$command);
+        $this->assertStringNotContainsString('unsigned', (string)$command);
+    }
+
+    public function test_it_accepts_signed_untrusted_phars()
+    {
+        $properties = [
+            'alias' => self::ALIAS,
+            'bin' => self::BIN,
+            'trust' => true,
+        ];
+
+        $command = PhiveInstallCommandFactory::import($properties);
+        $this->assertStringContainsString('trust', (string)$command);
+    }
+
+    public function test_it_accepts_unsigned_phars()
+    {
+        $properties = [
+            'alias' => self::ALIAS,
+            'bin' => self::BIN,
+            'unsigned' => true,
+        ];
+
+        $command = PhiveInstallCommandFactory::import($properties);
+        $this->assertStringContainsString('unsigned', (string)$command);
+    }
+
+    public function provideRequiredProperties(): \Generator
+    {
+        yield ['alias'];
+        yield ['bin'];
+    }
+}

--- a/tests/Json/Factory/ToolFactoryTest.php
+++ b/tests/Json/Factory/ToolFactoryTest.php
@@ -12,6 +12,7 @@ use Zalas\Toolbox\Tool\Command\ComposerInstallCommand;
 use Zalas\Toolbox\Tool\Command\FileDownloadCommand;
 use Zalas\Toolbox\Tool\Command\MultiStepCommand;
 use Zalas\Toolbox\Tool\Command\PharDownloadCommand;
+use Zalas\Toolbox\Tool\Command\PhiveInstallCommand;
 use Zalas\Toolbox\Tool\Command\ShCommand;
 use Zalas\Toolbox\Tool\Command\TestCommand;
 
@@ -67,6 +68,20 @@ class ToolFactoryTest extends TestCase
         ]));
 
         $this->assertInstanceOf(PharDownloadCommand::class, $tool->command());
+    }
+
+    public function test_it_imports_the_phive_install_command()
+    {
+        $tool = ToolFactory::import($this->definition([
+            'command' => [
+                'phive-install' => [
+                    'alias' => 'phpstan/phpstan',
+                    'bin' => 'tools'
+                ]
+            ]
+        ]));
+
+        $this->assertInstanceOf(PhiveInstallCommand::class, $tool->command());
     }
 
     public function test_it_imports_the_file_download_command()

--- a/tests/Tool/Command/PharDownloadCommandTest.php
+++ b/tests/Tool/Command/PharDownloadCommandTest.php
@@ -11,9 +11,6 @@ class PharDownloadCommandTest extends TestCase
     private const PHAR = 'https://example.com/foo.phar';
     private const BIN = '/usr/local/bin/foo';
 
-    /**
-     * @var FileDownloadCommand
-     */
     private $command;
 
     protected function setUp(): void

--- a/tests/Tool/Command/PhiveInstallCommandTest.php
+++ b/tests/Tool/Command/PhiveInstallCommandTest.php
@@ -1,0 +1,42 @@
+<?php declare(strict_types=1);
+
+namespace Zalas\Toolbox\Tests\Tool\Command;
+
+use PHPUnit\Framework\TestCase;
+use Zalas\Toolbox\Tool\Command;
+use Zalas\Toolbox\Tool\Command\PhiveInstallCommand;
+
+class PhiveInstallCommandTest extends TestCase
+{
+    private const ALIAS = 'example/foo';
+    private const BIN = '/usr/local/bin/foo';
+
+    private $command;
+
+    protected function setUp(): void
+    {
+        $this->command = new PhiveInstallCommand(self::ALIAS, self::BIN);
+    }
+
+    public function test_it_is_a_command()
+    {
+        $this->assertInstanceOf(Command::class, $this->command);
+    }
+
+    public function test_it_generates_the_installation_command()
+    {
+        $this->assertMatchesRegularExpression(\sprintf('#phive install(\s++)--trust-gpg-keys(\s++)%s -t %s#', self::ALIAS, self::BIN), (string) $this->command);
+    }
+
+    public function test_it_trusts_gpg_keys_command()
+    {
+        $command = new PhiveInstallCommand(self::ALIAS, self::BIN, false);
+        $this->assertMatchesRegularExpression(\sprintf('#phive install(\s++)%s -t %s#', self::ALIAS, self::BIN), (string) $command);
+    }
+
+    public function test_it_accepts_unsigned_phar_command()
+    {
+        $command = new PhiveInstallCommand(self::ALIAS, self::BIN, false, true);
+        $this->assertMatchesRegularExpression(\sprintf('#phive install(\s++)--force-accept-unsigned(\s++)%s -t %s#', self::ALIAS, self::BIN), (string) $command);
+    }
+}

--- a/tests/UseCase/InstallToolsTest.php
+++ b/tests/UseCase/InstallToolsTest.php
@@ -15,6 +15,7 @@ use Zalas\Toolbox\Tool\Command\ComposerInstallCommand;
 use Zalas\Toolbox\Tool\Command\FileDownloadCommand;
 use Zalas\Toolbox\Tool\Command\MultiStepCommand;
 use Zalas\Toolbox\Tool\Command\PharDownloadCommand;
+use Zalas\Toolbox\Tool\Command\PhiveInstallCommand;
 use Zalas\Toolbox\Tool\Command\ShCommand;
 use Zalas\Toolbox\Tool\Filter;
 use Zalas\Toolbox\Tool\Tool;
@@ -157,6 +158,17 @@ class InstallToolsTest extends TestCase
         $command = $this->useCase->__invoke($this->filter());
 
         $this->assertMatchesRegularExpression('#curl[^&]*?deptrac-0.2.0.phar#', (string)$command);
+    }
+
+    public function test_it_includes_phive_install_commands()
+    {
+        $this->tools->all(Argument::type(Filter::class))->willReturn(Collection::create([
+            $this->tool(new PhiveInstallCommand('phpunit', '/tools/phpunit')),
+        ]));
+
+        $command = $this->useCase->__invoke($this->filter());
+
+        $this->assertMatchesRegularExpression('#phive install[^&]*?phpunit[^&]*?/tools/phpunit#', (string)$command);
     }
 
     public function test_it_includes_file_download_commands()


### PR DESCRIPTION
Hi,

I'm trying to add [`phive`](https://phar.io/) as an installer here. It's prepackaged to do what `phar-download` does and I've seen various tool starting to recommend it as "the way" to install their tool.

WDYT?