### PR TITLE
Bump paratest to v6.2.0 and enable on php 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ It has been extracted as a separate project to make maintenance easier and enabl
 | larastan | [PHPStan extension for Laravel](https://github.com/nunomaduro/larastan) | &#x2705; | &#x2705; | &#x2705; |
 | local-php-security-checker | [Checks composer dependencies for known security vulnerabilities](https://github.com/fabpot/local-php-security-checker) | &#x2705; | &#x2705; | &#x2705; |
 | parallel-lint | [Checks PHP file syntax](https://github.com/JakubOnderka/PHP-Parallel-Lint) | &#x2705; | &#x2705; | &#x274C; |
-| paratest | [Parallel testing for PHPUnit](https://github.com/paratestphp/paratest) | &#x2705; | &#x2705; | &#x274C; |
+| paratest | [Parallel testing for PHPUnit](https://github.com/paratestphp/paratest) | &#x2705; | &#x2705; | &#x2705; |
 | pdepend | [Static Analysis Tool](https://pdepend.org/) | &#x2705; | &#x2705; | &#x2705; |
 | phan | [Static Analysis Tool](https://github.com/phan/phan) | &#x2705; | &#x2705; | &#x2705; |
 | phive | [PHAR Installation and Verification Environment](https://phar.io/) | &#x2705; | &#x2705; | &#x2705; |

--- a/resources/test.json
+++ b/resources/test.json
@@ -45,9 +45,10 @@
             "summary": "Parallel testing for PHPUnit",
             "website": "https://github.com/paratestphp/paratest",
             "command": {
-                "phive-install": {
-                    "alias": "paratestphp/paratest@^6.3.0",
-                    "bin": "%target-dir%/paratest"
+                "composer-bin-plugin": {
+                    "package": "brianium/paratest",
+                    "namespace": "paratest",
+                    "links": {"%target-dir%/paratest": "paratest"}
                 }
             },
             "test": "paratest --version",

--- a/resources/test.json
+++ b/resources/test.json
@@ -36,12 +36,12 @@
             "website": "https://github.com/paratestphp/paratest",
             "command": {
                 "phar-download": {
-                    "phar": "https://github.com/paratestphp/paratest/releases/download/5.0.4/paratest.phar",
+                    "phar": "https://github.com/paratestphp/paratest/releases/download/6.2.0/paratest.phar",
                     "bin": "%target-dir%/paratest"
                 }
             },
             "test": "paratest --version",
-            "tags": ["exclude-php:8.0", "test"]
+            "tags": ["test"]
         },
         {
             "name": "phpcov",


### PR DESCRIPTION
Linked to plan #357 