### PR TITLE
Enable phpDocumentor on php 8

### DIFF
--- a/resources/documentation.json
+++ b/resources/documentation.json
@@ -11,7 +11,7 @@
                 }
             },
             "test": "phpDocumentor list",
-            "tags": ["featured", "exclude-php:8.0", "documentation"]
+            "tags": ["featured", "documentation"]
         },
         {
             "name": "phpcb",


### PR DESCRIPTION
Phar version hasn't changed, still v3.0.0