### PR TITLE
Add Symplify extensions for Phpstan

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ It has been extracted as a separate project to make maintenance easier and enabl
 | phpstan-phpunit | [PHPUnit extensions and rules for PHPStan](https://github.com/phpstan/phpstan-phpunit) | &#x2705; | &#x2705; | &#x2705; |
 | phpstan-strict-rules | [Extra strict and opinionated rules for PHPStan](https://github.com/phpstan/phpstan-strict-rules) | &#x2705; | &#x2705; | &#x2705; |
 | phpstan-symfony | [Symfony extension for PHPStan](https://github.com/phpstan/phpstan-symfony) | &#x2705; | &#x2705; | &#x2705; |
+| phpstan-symplify | [Symplify extension for PHPStan](https://github.com/symplify/phpstan-rules) | &#x2705; | &#x2705; | &#x2705; |
 | phpstan-webmozart-assert | [PHPStan extension for webmozart/assert](https://github.com/phpstan/phpstan-webmozart-assert) | &#x2705; | &#x2705; | &#x2705; |
 | phpunit | [The PHP testing framework](https://phpunit.de/) | &#x2705; | &#x2705; | &#x2705; |
 | phpunit-5 | [The PHP testing framework (5.x version)](https://phpunit.de/) | &#x2705; | &#x2705; | &#x274C; |

--- a/resources/phpstan.json
+++ b/resources/phpstan.json
@@ -93,6 +93,19 @@
             "tags": ["phpstan"]
         },
         {
+            "name": "phpstan-symplify",
+            "summary": "Symplify extension for PHPStan",
+            "website": "https://github.com/symplify/phpstan-rules",
+            "command": {
+                "composer-bin-plugin": {
+                    "package": "symplify/phpstan-rules",
+                    "namespace": "phpstan"
+                }
+            },
+            "test": "composer global bin phpstan show symplify/phpstan-rules",
+            "tags": ["phpstan"]
+        },
+        {
             "name": "phpstan-beberlei-assert",
             "summary": "PHPStan extension for beberlei/assert",
             "website": "https://github.com/phpstan/phpstan-beberlei-assert",


### PR DESCRIPTION
The Symplify project is from Tomas Votruba who is also the maintainer of RectorPhp and Easy Coding Standard. I feel this extension would be a useful extension to the toolbox. 

Feel free to disagree as obviously it can also be installed manually by users that need it.

