### PR TITLE
Phive > Upgrade all phar-download to phive-install

### DIFF
--- a/resources/architecture.json
+++ b/resources/architecture.json
@@ -6,8 +6,9 @@
             "website": "https://dephpend.com/",
             "command": {
                 "phive-install": {
-                    "alias": "dephpend@^0.7.0",
-                    "bin": "%target-dir%/dephpend"
+                    "alias": "dephpend",
+                    "bin": "%target-dir%/dephpend",
+                    "sig": "76835C9464877BDD"
                 }
             },
             "test": "dephpend list",
@@ -19,8 +20,9 @@
             "website": "https://github.com/qossmic/deptrac",
             "command": {
                 "phive-install": {
-                    "alias": "qossmic/deptrac@^0.11.1",
-                    "bin": "%target-dir%/deptrac"
+                    "alias": "deptrac",
+                    "bin": "%target-dir%/deptrac",
+                    "sig": "4F2AB4D11A9A65F7"
                 }
             },
             "test": "deptrac list",
@@ -32,7 +34,7 @@
             "website": "https://pdepend.org/",
             "command": {
                 "phive-install": {
-                    "alias": "pdepend/pdepend@^2.8.0",
+                    "alias": "pdepend/pdepend@^2.0",
                     "bin": "%target-dir%/pdepend"
                 }
             },

--- a/resources/architecture.json
+++ b/resources/architecture.json
@@ -5,8 +5,8 @@
             "summary": "Detect flaws in your architecture",
             "website": "https://dephpend.com/",
             "command": {
-                "phar-download": {
-                    "phar": "https://github.com/mihaeu/dephpend/releases/download/0.7.0/dephpend-0.7.0.phar",
+                "phive-install": {
+                    "alias": "dephpend@^0.7.0",
                     "bin": "%target-dir%/dephpend"
                 }
             },
@@ -18,8 +18,8 @@
             "summary": "Enforces dependency rules between software layers",
             "website": "https://github.com/qossmic/deptrac",
             "command": {
-                "phar-download": {
-                    "phar": "https://github.com/qossmic/deptrac/releases/download/0.12.0/deptrac.phar",
+                "phive-install": {
+                    "alias": "qossmic/deptrac@^0.11.1",
                     "bin": "%target-dir%/deptrac"
                 }
             },
@@ -31,8 +31,8 @@
             "summary": "Static Analysis Tool",
             "website": "https://pdepend.org/",
             "command": {
-                "phar-download": {
-                    "phar": "https://github.com/pdepend/pdepend/releases/download/2.8.0/pdepend.phar",
+                "phive-install": {
+                    "alias": "pdepend/pdepend@^2.8.0",
                     "bin": "%target-dir%/pdepend"
                 }
             },

--- a/resources/checkstyle.json
+++ b/resources/checkstyle.json
@@ -21,7 +21,8 @@
             "command": {
                 "phive-install": {
                     "alias": "php-cs-fixer@^2.0",
-                    "bin": "%target-dir%/php-cs-fixer"
+                    "bin": "%target-dir%/php-cs-fixer",
+                    "sig": "E82B2FB314E9906E"
                 }
             },
             "test": "php-cs-fixer list",
@@ -49,7 +50,8 @@
             "command": {
                 "phive-install": {
                     "alias": "phpcbf",
-                    "bin": "%target-dir%/phpcbf"
+                    "bin": "%target-dir%/phpcbf",
+                    "sig": "31C7E470E2138192"
                 }
             },
             "test": "phpcbf --help",
@@ -61,9 +63,8 @@
             "website": "https://github.com/friendsoftwig/twigcs",
             "command": {
                 "phive-install": {
-                    "alias": "friendsoftwig/twigcs@^5.0.0",
-                    "bin": "%target-dir%/twigcs",
-                    "unsigned": true
+                    "alias": "friendsoftwig/twigcs@^5.0",
+                    "bin": "%target-dir%/twigcs"
                 }
             },
             "test": "twigcs --help",

--- a/resources/checkstyle.json
+++ b/resources/checkstyle.json
@@ -19,8 +19,8 @@
             "summary": "PHP Coding Standards Fixer",
             "website": "http://cs.symfony.com/",
             "command": {
-                "phar-download": {
-                    "phar": "http://cs.symfony.com/download/php-cs-fixer-v2.phar",
+                "phive-install": {
+                    "alias": "php-cs-fixer@^2.0",
                     "bin": "%target-dir%/php-cs-fixer"
                 }
             },
@@ -47,8 +47,8 @@
             "summary": "Automatically corrects coding standard violations",
             "website": "https://github.com/squizlabs/PHP_CodeSniffer",
             "command": {
-                "phar-download": {
-                    "phar": "https://squizlabs.github.io/PHP_CodeSniffer/phpcbf.phar",
+                "phive-install": {
+                    "alias": "phpcbf",
                     "bin": "%target-dir%/phpcbf"
                 }
             },
@@ -60,9 +60,10 @@
             "summary": "The missing checkstyle for twig!",
             "website": "https://github.com/friendsoftwig/twigcs",
             "command": {
-                "phar-download": {
-                    "phar": "https://github.com/friendsoftwig/twigcs/releases/download/v5.0.0/twigcs.phar",
-                    "bin": "%target-dir%/twigcs"
+                "phive-install": {
+                    "alias": "friendsoftwig/twigcs@^5.0.0",
+                    "bin": "%target-dir%/twigcs",
+                    "unsigned": true
                 }
             },
             "test": "twigcs --help",

--- a/resources/compatibility.json
+++ b/resources/compatibility.json
@@ -18,9 +18,10 @@
             "summary": "Tool to compare two revisions of a class API to check for BC breaks",
             "website": "https://github.com/Roave/BackwardCompatibilityCheck",
             "command": {
-                "phar-download": {
-                    "phar": "https://github.com/Roave/BackwardCompatibilityCheck/releases/download/5.0.0/roave-backward-compatibility-check.phar",
-                    "bin": "%target-dir%/roave-backward-compatibility-check"
+                "phive-install": {
+                    "alias": "Roave/BackwardCompatibilityCheck@^5.0.0",
+                    "bin": "%target-dir%/roave-backward-compatibility-check",
+                    "unsigned": true
                 }
             },
             "test": "roave-backward-compatibility-check --version",

--- a/resources/compatibility.json
+++ b/resources/compatibility.json
@@ -19,9 +19,8 @@
             "website": "https://github.com/Roave/BackwardCompatibilityCheck",
             "command": {
                 "phive-install": {
-                    "alias": "Roave/BackwardCompatibilityCheck@^5.0.0",
-                    "bin": "%target-dir%/roave-backward-compatibility-check",
-                    "unsigned": true
+                    "alias": "roave/backwardcompatibilitycheck@^5.0",
+                    "bin": "%target-dir%/roave-backward-compatibility-check"
                 }
             },
             "test": "roave-backward-compatibility-check --version",

--- a/resources/composer.json
+++ b/resources/composer.json
@@ -17,8 +17,8 @@
             "summary": "Show unused packages by scanning your code",
             "website": "https://github.com/icanhazstring/composer-unused",
             "command": {
-                "phar-download": {
-                    "phar": "https://github.com/composer-unused/composer-unused/releases/download/0.7.5/composer-unused.phar",
+                "phive-install": {
+                    "alias": "composer-unused@^0.7.5",
                     "bin": "%target-dir%/composer-unused"
                 }
             },

--- a/resources/composer.json
+++ b/resources/composer.json
@@ -18,8 +18,9 @@
             "website": "https://github.com/icanhazstring/composer-unused",
             "command": {
                 "phive-install": {
-                    "alias": "composer-unused@^0.7.5",
-                    "bin": "%target-dir%/composer-unused"
+                    "alias": "composer-unused",
+                    "bin": "%target-dir%/composer-unused",
+                    "sig": "F4D32E2C9343B2AE"
                 }
             },
             "test": "composer-unused -vvv | grep 'Your system is ready'",
@@ -30,13 +31,10 @@
             "summary": "Verify that no unknown symbols are used in the sources of a package.",
             "website": "https://github.com/maglnet/ComposerRequireChecker",
             "command": {
-                "file-download": {
-                    "url": "https://github.com/maglnet/ComposerRequireChecker/releases/download/3.1.0/composer-require-checker.phar.asc",
-                    "file": "%target-dir%/composer-require-checker.asc"
-                },
-                "phar-download": {
-                    "phar": "https://github.com/maglnet/ComposerRequireChecker/releases/download/3.1.0/composer-require-checker.phar",
-                    "bin": "%target-dir%/composer-require-checker"
+                "phive-install": {
+                    "alias": "composer-require-checker",
+                    "bin": "%target-dir%/composer-require-checker",
+                    "sig": "033E5F8D801A2F8D"
                 }
             },
             "test": "composer-require-checker -V",
@@ -47,13 +45,10 @@
             "summary": "Verify that no unknown symbols are used in the sources of a package.",
             "website": "https://github.com/maglnet/ComposerRequireChecker",
             "command": {
-                "file-download": {
-                    "url": "https://github.com/maglnet/ComposerRequireChecker/releases/download/2.1.0/composer-require-checker.phar.asc",
-                    "file": "%target-dir%/composer-require-checker-v2.asc"
-                },
-                "phar-download": {
-                    "phar": "https://github.com/maglnet/ComposerRequireChecker/releases/download/2.1.0/composer-require-checker.phar",
-                    "bin": "%target-dir%/composer-require-checker-v2"
+                "phive-install": {
+                    "alias": "composer-require-checker@^2.0",
+                    "bin": "%target-dir%/composer-require-checker-v2",
+                    "sig": "D2CCAC42F6295E7D"
                 }
             },
             "test": "composer-require-checker-v2 -V",

--- a/resources/deprecation.json
+++ b/resources/deprecation.json
@@ -5,9 +5,10 @@
             "summary": "Finds usages of deprecated code",
             "website": "https://github.com/sensiolabs-de/deprecation-detector",
             "command": {
-                "phar-download": {
-                    "phar": "https://github.com/sensiolabs-de/deprecation-detector/releases/download/0.1.0-alpha4/deprecation-detector.phar",
-                    "bin": "%target-dir%/deprecation-detector"
+                "phive-install": {
+                    "alias": "sensiolabs-de/deprecation-detector@^0.1.0-alpha4",
+                    "bin": "%target-dir%/deprecation-detector",
+                    "unsigned": true
                 }
             },
             "test": "deprecation-detector list",
@@ -18,9 +19,10 @@
             "summary": "Finds usage of deprecated features",
             "website": "http://wapmorgan.github.io/PhpDeprecationDetector",
             "command": {
-                "phar-download": {
-                    "phar": "https://github.com/wapmorgan/PhpDeprecationDetector/releases/download/2.0.25/phpdd-2.0.25.phar",
-                    "bin": "%target-dir%/phpdd"
+                "phive-install": {
+                    "alias": "wapmorgan/PhpDeprecationDetector@^2.0.25",
+                    "bin": "%target-dir%/phpdd",
+                    "unsigned": true
                 }
             },
             "test": "phpdd -h",

--- a/resources/deprecation.json
+++ b/resources/deprecation.json
@@ -6,9 +6,8 @@
             "website": "https://github.com/sensiolabs-de/deprecation-detector",
             "command": {
                 "phive-install": {
-                    "alias": "sensiolabs-de/deprecation-detector@^0.1.0-alpha4",
-                    "bin": "%target-dir%/deprecation-detector",
-                    "unsigned": true
+                    "alias": "sensiolabs-de/deprecation-detector",
+                    "bin": "%target-dir%/deprecation-detector"
                 }
             },
             "test": "deprecation-detector list",
@@ -20,9 +19,8 @@
             "website": "http://wapmorgan.github.io/PhpDeprecationDetector",
             "command": {
                 "phive-install": {
-                    "alias": "wapmorgan/PhpDeprecationDetector@^2.0.25",
-                    "bin": "%target-dir%/phpdd",
-                    "unsigned": true
+                    "alias": "wapmorgan/phpdeprecationdetector@^2.0",
+                    "bin": "%target-dir%/phpdd"
                 }
             },
             "test": "phpdd -h",

--- a/resources/documentation.json
+++ b/resources/documentation.json
@@ -8,7 +8,7 @@
                 "phive-install": {
                     "alias": "phpDocumentor",
                     "bin": "%target-dir%/phpDocumentor",
-                    "unsigned": true
+                    "sig": "6DA3ACC4991FFAE5"
                 }
             },
             "test": "phpDocumentor list",

--- a/resources/documentation.json
+++ b/resources/documentation.json
@@ -5,9 +5,10 @@
             "summary": "Documentation generator",
             "website": "https://www.phpdoc.org/",
             "command": {
-                "phar-download": {
-                    "phar": "https://github.com/phpDocumentor/phpDocumentor/releases/download/v3.0.0/phpDocumentor.phar",
-                    "bin": "%target-dir%/phpDocumentor"
+                "phive-install": {
+                    "alias": "phpDocumentor",
+                    "bin": "%target-dir%/phpDocumentor",
+                    "unsigned": true
                 }
             },
             "test": "phpDocumentor list",

--- a/resources/linting.json
+++ b/resources/linting.json
@@ -19,10 +19,9 @@
             "summary": "Lints php files in parallel",
             "website": "https://github.com/overtrue/phplint",
             "command": {
-                "composer-bin-plugin": {
-                    "package": "overtrue/phplint",
-                    "namespace": "tools",
-                    "links": {"%target-dir%/phplint": "phplint"}
+                "phive-install": {
+                    "alias": "overtrue/phplint",
+                    "bin": "%target-dir%/phplint"
                 }
             },
             "test": "phplint -V",

--- a/resources/linting.json
+++ b/resources/linting.json
@@ -46,9 +46,10 @@
             "summary": "Compact command line utility for checking YAML file syntax",
             "website": "https://github.com/j13k/yaml-lint",
             "command": {
-                "phar-download": {
-                    "phar": "https://github.com/j13k/yaml-lint/releases/download/1.1.4/yaml-lint.phar",
-                    "bin": "%target-dir%/yaml-lint"
+                "phive-install": {
+                    "alias": "j13k/yaml-lint@^1.1.3",
+                    "bin": "%target-dir%/yaml-lint",
+                    "sig": "D684BDC6C6CAB80F"
                 }
             },
             "test": "yaml-lint --version",

--- a/resources/metrics.json
+++ b/resources/metrics.json
@@ -32,8 +32,8 @@
             "summary": "A tool for quickly measuring the size of a PHP project",
             "website": "https://github.com/sebastianbergmann/phploc",
             "command": {
-                "phar-download": {
-                    "phar": "https://phar.phpunit.de/phploc.phar",
+                "phive-install": {
+                    "alias": "phploc",
                     "bin": "%target-dir%/phploc"
                 }
             },
@@ -45,8 +45,8 @@
             "summary": "Static Analysis Tool",
             "website": "http://www.phpmetrics.org/",
             "command": {
-                "phar-download": {
-                    "phar": "https://github.com/phpmetrics/PhpMetrics/releases/download/v2.7.3/phpmetrics.phar",
+                "phive-install": {
+                    "alias": "https://github.com/phpmetrics/PhpMetrics/releases/download/v2.7.3/phpmetrics.phar",
                     "bin": "%target-dir%/phpmetrics"
                 }
             },

--- a/resources/metrics.json
+++ b/resources/metrics.json
@@ -34,7 +34,8 @@
             "command": {
                 "phive-install": {
                     "alias": "phploc",
-                    "bin": "%target-dir%/phploc"
+                    "bin": "%target-dir%/phploc",
+                    "sig": "4AA394086372C20A"
                 }
             },
             "test": "phploc -v",
@@ -46,7 +47,7 @@
             "website": "http://www.phpmetrics.org/",
             "command": {
                 "phive-install": {
-                    "alias": "https://github.com/phpmetrics/PhpMetrics/releases/download/v2.7.3/phpmetrics.phar",
+                    "alias": "phpmetrics/PhpMetrics@^2.0",
                     "bin": "%target-dir%/phpmetrics"
                 }
             },

--- a/resources/pre-installation.json
+++ b/resources/pre-installation.json
@@ -48,9 +48,10 @@
       "summary": "Fast, zero config application bundler with PHARs",
       "website": "https://github.com/humbug/box",
       "command": {
-        "phar-download": {
-          "phar": "https://github.com/humbug/box/releases/download/3.11.1/box.phar",
-          "bin": "%target-dir%/box"
+        "phive-install": {
+          "alias": "humbug/box@^3.11.1",
+          "bin": "%target-dir%/box",
+          "unsigned": true
         }
       },
       "test": "box list",

--- a/resources/pre-installation.json
+++ b/resources/pre-installation.json
@@ -20,9 +20,6 @@
         "phar-download": {
           "phar": "https://phar.io/releases/phive.phar",
           "bin": "%target-dir%/phive"
-        },
-        "sh": {
-          "command": "phive --home %target-dir%"
         }
       },
       "test": "phive --version",
@@ -49,9 +46,8 @@
       "website": "https://github.com/humbug/box",
       "command": {
         "phive-install": {
-          "alias": "humbug/box@^3.11.1",
-          "bin": "%target-dir%/box",
-          "unsigned": true
+          "alias": "humbug/box@^3.0",
+          "bin": "%target-dir%/box"
         }
       },
       "test": "box list",
@@ -62,8 +58,10 @@
       "summary": "Legacy version of box",
       "website": "https://box-project.github.io/box2/",
       "command": {
-        "sh": {
-          "command": "curl -Ls https://box-project.github.io/box2/installer.php | php && mv box.phar %target-dir%/box-legacy && chmod +x %target-dir%/box-legacy"
+        "phive-install": {
+          "alias": "box-project/box2",
+          "bin": "%target-dir%/box-legacy",
+          "sig": "293D771241515FE8"
         }
       },
       "test": "box-legacy list",

--- a/resources/pre-installation.json
+++ b/resources/pre-installation.json
@@ -13,6 +13,22 @@
       "tags": ["pre-installation"]
     },
     {
+      "name": "phive",
+      "summary": "PHAR Installation and Verification Environment",
+      "website": "https://phar.io/",
+      "command": {
+        "phar-download": {
+          "phar": "https://phar.io/releases/phive.phar",
+          "bin": "%target-dir%/phive"
+        },
+        "sh": {
+          "command": "phive --home %target-dir%"
+        }
+      },
+      "test": "phive --version",
+      "tags": ["pre-installation"]
+    },
+    {
       "name": "composer-bin-plugin",
       "summary": "Composer plugin to install bin vendors in isolated locations",
       "website": "https://github.com/bamarni/composer-bin-plugin",

--- a/resources/refactoring.json
+++ b/resources/refactoring.json
@@ -6,8 +6,9 @@
             "website": "https://github.com/bmitch/churn-php",
             "command": {
                 "phive-install": {
-                    "alias": "churn@^1.5.0",
-                    "bin": "%target-dir%/churn"
+                    "alias": "churn@^1.0",
+                    "bin": "%target-dir%/churn",
+                    "sig": "69132CC8829FAB5F"
                 }
             },
             "test": "churn --version",
@@ -20,8 +21,7 @@
             "command": {
                 "phive-install": {
                     "alias": "dunglas/phpdoc-to-typehint@^0.1.0",
-                    "bin": "%target-dir%/phpdoc-to-typehint",
-                    "unsigned": true
+                    "bin": "%target-dir%/phpdoc-to-typehint"
                 }
             },
             "test": "phpdoc-to-typehint -V",

--- a/resources/refactoring.json
+++ b/resources/refactoring.json
@@ -5,12 +5,8 @@
             "summary": "Discovers good candidates for refactoring",
             "website": "https://github.com/bmitch/churn-php",
             "command": {
-                "file-download": {
-                    "url": "https://github.com/bmitch/churn-php/releases/download/1.5.0/churn.phar.asc",
-                    "file": "%target-dir%/churn.phar.asc"
-                },
-                "phar-download": {
-                    "phar": "https://github.com/bmitch/churn-php/releases/download/1.5.0/churn.phar",
+                "phive-install": {
+                    "alias": "churn@^1.5.0",
                     "bin": "%target-dir%/churn"
                 }
             },
@@ -22,9 +18,10 @@
             "summary": "Automatically adds type hints and return types based on PHPDocs",
             "website": "https://github.com/dunglas/phpdoc-to-typehint",
             "command": {
-                "phar-download": {
-                    "phar": "https://github.com/dunglas/phpdoc-to-typehint/releases/download/v0.1.0/phpdoc-to-typehint.phar",
-                    "bin": "%target-dir%/phpdoc-to-typehint"
+                "phive-install": {
+                    "alias": "dunglas/phpdoc-to-typehint@^0.1.0",
+                    "bin": "%target-dir%/phpdoc-to-typehint",
+                    "unsigned": true
                 }
             },
             "test": "phpdoc-to-typehint -V",

--- a/resources/test.json
+++ b/resources/test.json
@@ -30,13 +30,8 @@
             "name": "infection",
             "summary": "AST based PHP Mutation Testing Framework",
             "website": "https://infection.github.io/",
-            "command": {
-                "file-download": {
-                    "url": "https://github.com/infection/infection/releases/download/0.21.4/infection.phar.asc",
-                    "file": "%target-dir%/infection.phar.asc"
-                },
-                "phar-download": {
-                    "phar": "https://github.com/infection/infection/releases/download/0.21.4/infection.phar",
+                "phive-install": {
+                    "alias": "infection@^0.21",
                     "bin": "%target-dir%/infection"
                 }
             },
@@ -48,9 +43,10 @@
             "summary": "Parallel testing for PHPUnit",
             "website": "https://github.com/paratestphp/paratest",
             "command": {
-                "phar-download": {
-                    "phar": "https://github.com/paratestphp/paratest/releases/download/5.0.4/paratest.phar",
-                    "bin": "%target-dir%/paratest"
+                "phive-install": {
+                    "alias": "paratestphp/paratest@^5.0.4",
+                    "bin": "%target-dir%/paratest",
+                    "unsigned": true
                 }
             },
             "test": "paratest --version",
@@ -61,8 +57,8 @@
             "summary": "a command-line frontend for the PHP_CodeCoverage library",
             "website": "https://github.com/sebastianbergmann/phpcov",
             "command": {
-                "phar-download": {
-                    "phar": "https://phar.phpunit.de/phpcov.phar",
+                "phive-install": {
+                    "alias": "phpcov",
                     "bin": "%target-dir%/phpcov"
                 }
             },
@@ -74,9 +70,10 @@
             "summary": "SpecBDD Framework",
             "website": "http://www.phpspec.net/",
             "command": {
-                "phar-download": {
-                    "phar": "https://github.com/phpspec/phpspec/releases/download/7.0.1/phpspec.phar",
-                    "bin": "%target-dir%/phpspec"
+                "phive-install": {
+                    "alias": "https://github.com/phpspec/phpspec/releases/download/7.0.1/phpspec.phar",
+                    "bin": "%target-dir%/phpspec",
+                    "unsigned": true
                 }
             },
             "test": "phpspec --version",
@@ -87,8 +84,8 @@
             "summary": "The PHP testing framework",
             "website": "https://phpunit.de/",
             "command": {
-                "phar-download": {
-                    "phar": "https://phar.phpunit.de/phpunit.phar",
+                "phive-install": {
+                    "alias": "phpunit",
                     "bin": "%target-dir%/phpunit"
                 }
             },
@@ -100,8 +97,8 @@
             "summary": "The PHP testing framework (8.x version)",
             "website": "https://phpunit.de/",
             "command": {
-                "phar-download": {
-                    "phar": "https://phar.phpunit.de/phpunit-8.phar",
+                "phive-install": {
+                    "alias": "phpunit@^8.0",
                     "bin": "%target-dir%/phpunit-8"
                 }
             },
@@ -113,8 +110,8 @@
             "summary": "The PHP testing framework (7.x version)",
             "website": "https://phpunit.de/",
             "command": {
-                "phar-download": {
-                    "phar": "https://phar.phpunit.de/phpunit-7.phar",
+                "phive-install": {
+                    "alias": "phpunit@^7.0",
                     "bin": "%target-dir%/phpunit-7"
                 }
             },
@@ -126,8 +123,8 @@
             "summary": "The PHP testing framework (5.x version)",
             "website": "https://phpunit.de/",
             "command": {
-                "phar-download": {
-                    "phar": "https://phar.phpunit.de/phpunit-5.phar",
+                "phive-install": {
+                    "alias": "phpunit@^5.0",
                     "bin": "%target-dir%/phpunit-5"
                 }
             },

--- a/resources/test.json
+++ b/resources/test.json
@@ -30,9 +30,11 @@
             "name": "infection",
             "summary": "AST based PHP Mutation Testing Framework",
             "website": "https://infection.github.io/",
+            "command": {
                 "phive-install": {
                     "alias": "infection@^0.21",
-                    "bin": "%target-dir%/infection"
+                    "bin": "%target-dir%/infection",
+                    "sig": "C5095986493B4AA0"
                 }
             },
             "test": "infection --version",
@@ -45,8 +47,7 @@
             "command": {
                 "phive-install": {
                     "alias": "paratestphp/paratest@^5.0.4",
-                    "bin": "%target-dir%/paratest",
-                    "unsigned": true
+                    "bin": "%target-dir%/paratest"
                 }
             },
             "test": "paratest --version",
@@ -59,7 +60,8 @@
             "command": {
                 "phive-install": {
                     "alias": "phpcov",
-                    "bin": "%target-dir%/phpcov"
+                    "bin": "%target-dir%/phpcov",
+                    "sig": "4AA394086372C20A"
                 }
             },
             "test": "phpcov -v",
@@ -71,9 +73,8 @@
             "website": "http://www.phpspec.net/",
             "command": {
                 "phive-install": {
-                    "alias": "https://github.com/phpspec/phpspec/releases/download/7.0.1/phpspec.phar",
-                    "bin": "%target-dir%/phpspec",
-                    "unsigned": true
+                    "alias": "phpspec/phpspec@^7.0",
+                    "bin": "%target-dir%/phpspec"
                 }
             },
             "test": "phpspec --version",
@@ -86,7 +87,8 @@
             "command": {
                 "phive-install": {
                     "alias": "phpunit",
-                    "bin": "%target-dir%/phpunit"
+                    "bin": "%target-dir%/phpunit",
+                    "sig": "4AA394086372C20A"
                 }
             },
             "test": "phpunit --version",
@@ -99,7 +101,8 @@
             "command": {
                 "phive-install": {
                     "alias": "phpunit@^8.0",
-                    "bin": "%target-dir%/phpunit-8"
+                    "bin": "%target-dir%/phpunit-8",
+                    "sig": "4AA394086372C20A"
                 }
             },
             "test": "phpunit-8 --version",
@@ -112,7 +115,8 @@
             "command": {
                 "phive-install": {
                     "alias": "phpunit@^7.0",
-                    "bin": "%target-dir%/phpunit-7"
+                    "bin": "%target-dir%/phpunit-7",
+                    "sig": "4AA394086372C20A"
                 }
             },
             "test": "phpunit-7 --version",
@@ -125,7 +129,8 @@
             "command": {
                 "phive-install": {
                     "alias": "phpunit@^5.0",
-                    "bin": "%target-dir%/phpunit-5"
+                    "bin": "%target-dir%/phpunit-5",
+                    "sig": "4AA394086372C20A"
                 }
             },
             "test": "phpunit-5 --version",

--- a/resources/tools.json
+++ b/resources/tools.json
@@ -21,7 +21,8 @@
       "command": {
         "phive-install": {
           "alias": "phan@^4.0.3",
-          "bin": "%target-dir%/phan"
+          "bin": "%target-dir%/phan",
+          "sig": "8101FB57DD8130F0"
         }
       },
       "test": "phan -v",
@@ -33,11 +34,13 @@
       "website": "https://github.com/phpbench/phpbench",
       "command": {
         "phive-install": {
-          "alias": "phpbench/phpbench",
-          "bin": "%target-dir%/phpbench"
+          "alias": "phpbench",
+          "bin": "%target-dir%/phpbench",
+          "sig": "D0254321FB74703A"
         }
       },
-      "test": "phpbench"
+      "test": "phpbench",
+      "tags": ["exclude-php:8.0"]
     },
     {
       "name": "phpa",
@@ -73,7 +76,8 @@
       "command": {
         "phive-install": {
           "alias": "phpcpd",
-          "bin": "%target-dir%/phpcpd"
+          "bin": "%target-dir%/phpcpd",
+          "sig": "4AA394086372C20A"
         }
       },
       "test": "phpcpd -v",
@@ -85,8 +89,9 @@
       "website": "https://phpmd.org/",
       "command": {
         "phive-install": {
-          "alias": "phpmd@^2.9.1",
-          "bin": "%target-dir%/phpmd"
+          "alias": "phpmd",
+          "bin": "%target-dir%/phpmd",
+          "sig": "0F9684B8B16B7AB0"
         }
       },
       "test": "phpmd --version"

--- a/resources/tools.json
+++ b/resources/tools.json
@@ -19,8 +19,8 @@
       "summary": "Static Analysis Tool",
       "website": "https://github.com/phan/phan",
       "command": {
-        "phar-download": {
-          "phar": "https://github.com/phan/phan/releases/download/4.0.3/phan.phar",
+        "phive-install": {
+          "alias": "phan@^4.0.3",
           "bin": "%target-dir%/phan"
         }
       },
@@ -32,12 +32,8 @@
       "summary": "PHP Benchmarking framework",
       "website": "https://github.com/phpbench/phpbench",
       "command": {
-        "file-download": {
-          "url": "https://phpbench.github.io/phpbench/phpbench.phar.pubkey",
-          "file": "%target-dir%/phpbench.pubkey"
-        },
-        "phar-download": {
-          "phar": "https://phpbench.github.io/phpbench/phpbench.phar",
+        "phive-install": {
+          "alias": "phpbench/phpbench",
           "bin": "%target-dir%/phpbench"
         }
       },
@@ -75,8 +71,8 @@
       "summary": "Copy/Paste Detector",
       "website": "https://github.com/sebastianbergmann/phpcpd",
       "command": {
-        "phar-download": {
-          "phar": "https://phar.phpunit.de/phpcpd.phar",
+        "phive-install": {
+          "alias": "phpcpd",
           "bin": "%target-dir%/phpcpd"
         }
       },
@@ -88,8 +84,8 @@
       "summary": "A tool for finding problems in PHP code",
       "website": "https://phpmd.org/",
       "command": {
-        "phar-download": {
-          "phar": "https://github.com/phpmd/phpmd/releases/download/2.9.1/phpmd.phar",
+        "phive-install": {
+          "alias": "phpmd@^2.9.1",
           "bin": "%target-dir%/phpmd"
         }
       },

--- a/src/Json/Factory/PhiveInstallCommandFactory.php
+++ b/src/Json/Factory/PhiveInstallCommandFactory.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types=1);
+
+namespace Zalas\Toolbox\Json\Factory;
+
+use Zalas\Toolbox\Tool\Command;
+use Zalas\Toolbox\Tool\Command\PhiveInstallCommand;
+
+final class PhiveInstallCommandFactory
+{
+    public static function import(array $command): Command
+    {
+        Assert::requireFields(['alias', 'bin'], $command, 'PhiveInstallCommand');
+
+        return new PhiveInstallCommand($command['alias'], $command['bin'], $command['trust'] ?? false, $command['unsigned'] ?? false);
+    }
+}

--- a/src/Json/Factory/PhiveInstallCommandFactory.php
+++ b/src/Json/Factory/PhiveInstallCommandFactory.php
@@ -11,6 +11,6 @@ final class PhiveInstallCommandFactory
     {
         Assert::requireFields(['alias', 'bin'], $command, 'PhiveInstallCommand');
 
-        return new PhiveInstallCommand($command['alias'], $command['bin'], $command['trust'] ?? false, $command['unsigned'] ?? false);
+        return new PhiveInstallCommand($command['alias'], $command['bin'], $command['sig'] ?? null);
     }
 }

--- a/src/Json/Factory/ToolFactory.php
+++ b/src/Json/Factory/ToolFactory.php
@@ -46,6 +46,7 @@ final class ToolFactory
             'file-download' => \sprintf('%s::import', FileDownloadCommandFactory::class),
             'box-build' => \sprintf('%s::import', BoxBuildCommandFactory::class),
             'composer-install' => \sprintf('%s::import', ComposerInstallCommandFactory::class),
+            'phive-install' => \sprintf('%s::import', PhiveInstallCommandFactory::class),
             'composer-global-install' => \sprintf('%s::import', ComposerGlobalInstallCommandFactory::class),
             'composer-bin-plugin' => \sprintf('%s::import', ComposerBinPluginCommandFactory::class),
             'sh' => \sprintf('%s::import', ShCommandFactory::class),

--- a/src/Tool/Command/PhiveInstallCommand.php
+++ b/src/Tool/Command/PhiveInstallCommand.php
@@ -8,24 +8,27 @@ final class PhiveInstallCommand implements Command
 {
     private $alias;
     private $bin;
-    private $trust;
-    private $unsigned;
+    private $sig;
 
-    public function __construct(string $alias, string $bin, bool $trust = true, bool $unsigned = false)
+    public function __construct(string $alias, string $bin, ?string $sig = null)
     {
         $this->alias = $alias;
         $this->bin = $bin;
-        $this->trust = $trust;
-        $this->unsigned = $unsigned;
+        $this->sig = $sig;
     }
 
     public function __toString(): string
     {
+        $home = \dirname($this->bin);
+        $tmp = '/tmp/'.\md5($this->alias);
+
         return \sprintf(
-            'phive install %s %s %s -t %s',
-            $this->trust ? '--trust-gpg-keys' : '',
-            $this->unsigned ? '--force-accept-unsigned' : '',
+            'phive --no-progress --home %s install %s %s -t %s && mv %s/* %s',
+            $home,
+            $this->sig ? '--trust-gpg-keys '.$this->sig : '--force-accept-unsigned',
             $this->alias,
+            $tmp,
+            $tmp,
             $this->bin
         );
     }

--- a/src/Tool/Command/PhiveInstallCommand.php
+++ b/src/Tool/Command/PhiveInstallCommand.php
@@ -1,0 +1,32 @@
+<?php declare(strict_types=1);
+
+namespace Zalas\Toolbox\Tool\Command;
+
+use Zalas\Toolbox\Tool\Command;
+
+final class PhiveInstallCommand implements Command
+{
+    private $alias;
+    private $bin;
+    private $trust;
+    private $unsigned;
+
+    public function __construct(string $alias, string $bin, bool $trust = true, bool $unsigned = false)
+    {
+        $this->alias = $alias;
+        $this->bin = $bin;
+        $this->trust = $trust;
+        $this->unsigned = $unsigned;
+    }
+
+    public function __toString(): string
+    {
+        return \sprintf(
+            'phive install %s %s %s -t %s',
+            $this->trust ? '--trust-gpg-keys' : '',
+            $this->unsigned ? '--force-accept-unsigned' : '',
+            $this->alias,
+            $this->bin
+        );
+    }
+}

--- a/src/Tool/Command/PhiveInstallCommand.php
+++ b/src/Tool/Command/PhiveInstallCommand.php
@@ -20,14 +20,16 @@ final class PhiveInstallCommand implements Command
     public function __toString(): string
     {
         $home = \sprintf('%s/.phive', \dirname($this->bin));
-        $target = \dirname($this->bin);
+        $tmp = \sprintf('%s/tmp/%s', $home, \md5($this->alias));
 
         return \sprintf(
-            'phive --no-progress --home %s install %s %s -t %s',
+            'phive --no-progress --home %s install %s %s -t %s && mv %s/* %s',
             $home,
             $this->sig ? '--trust-gpg-keys '.$this->sig : '--force-accept-unsigned',
             $this->alias,
-            $target
+            $tmp,
+            $tmp,
+            $this->bin
         );
     }
 }

--- a/src/Tool/Command/PhiveInstallCommand.php
+++ b/src/Tool/Command/PhiveInstallCommand.php
@@ -19,17 +19,15 @@ final class PhiveInstallCommand implements Command
 
     public function __toString(): string
     {
-        $home = \dirname($this->bin);
-        $tmp = '/tmp/'.\md5($this->alias);
+        $home = \sprintf('%s/.phive', \dirname($this->bin));
+        $target = \dirname($this->bin);
 
         return \sprintf(
-            'phive --no-progress --home %s install %s %s -t %s && mv %s/* %s',
+            'phive --no-progress --home %s install %s %s -t %s',
             $home,
             $this->sig ? '--trust-gpg-keys '.$this->sig : '--force-accept-unsigned',
             $this->alias,
-            $tmp,
-            $tmp,
-            $this->bin
+            $target
         );
     }
 }

--- a/src/UseCase/InstallTools.php
+++ b/src/UseCase/InstallTools.php
@@ -14,6 +14,7 @@ use Zalas\Toolbox\Tool\Command\FileDownloadCommand;
 use Zalas\Toolbox\Tool\Command\MultiStepCommand;
 use Zalas\Toolbox\Tool\Command\OptimisedComposerBinPluginCommand;
 use Zalas\Toolbox\Tool\Command\PharDownloadCommand;
+use Zalas\Toolbox\Tool\Command\PhiveInstallCommand;
 use Zalas\Toolbox\Tool\Command\ShCommand;
 use Zalas\Toolbox\Tool\Filter;
 use Zalas\Toolbox\Tool\Tool;
@@ -41,6 +42,7 @@ class InstallTools
                 ->merge($commandFilter(ShCommand::class))
                 ->merge($commandFilter(FileDownloadCommand::class))
                 ->merge($commandFilter(PharDownloadCommand::class))
+                ->merge($commandFilter(PhiveInstallCommand::class))
                 ->merge($commandFilter(MultiStepCommand::class))
                 ->merge($this->groupComposerGlobalInstallCommands($commandFilter(ComposerGlobalInstallCommand::class)))
                 ->merge($this->groupComposerBinPluginCommands($commandFilter(ComposerBinPluginCommand::class)))

--- a/tests/Json/Factory/PhiveInstallCommandFactoryTest.php
+++ b/tests/Json/Factory/PhiveInstallCommandFactoryTest.php
@@ -1,0 +1,82 @@
+<?php declare(strict_types=1);
+
+namespace Zalas\Toolbox\Tests\Json\Factory;
+
+use PHPUnit\Framework\TestCase;
+use Zalas\Toolbox\Json\Factory\PhiveInstallCommandFactory;
+use Zalas\Toolbox\Tool\Command\PhiveInstallCommand;
+
+class PhiveInstallCommandFactoryTest extends TestCase
+{
+    private const ALIAS = 'example/foo';
+    private const BIN = '/usr/local/bin/foo';
+
+    public function test_it_creates_a_command()
+    {
+        $command = PhiveInstallCommandFactory::import([
+            'alias' => self::ALIAS,
+            'bin' => self::BIN,
+        ]);
+        
+        $this->assertInstanceOf(PhiveInstallCommand::class, $command);
+    }
+
+    /**
+     * @dataProvider provideRequiredProperties
+     */
+    public function test_it_complains_if_any_of_required_properties_is_missing(string $property)
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $properties = [
+            'alias' => self::ALIAS,
+            'bin' => self::BIN,
+        ];
+
+        unset($properties[$property]);
+
+        PhiveInstallCommandFactory::import($properties);
+    }
+
+    public function test_it_accepts_signed_trusted_phars()
+    {
+        $properties = [
+            'alias' => self::ALIAS,
+            'bin' => self::BIN,
+        ];
+
+        $command = PhiveInstallCommandFactory::import($properties);
+        $this->assertStringNotContainsString('trust', (string)$command);
+        $this->assertStringNotContainsString('unsigned', (string)$command);
+    }
+
+    public function test_it_accepts_signed_untrusted_phars()
+    {
+        $properties = [
+            'alias' => self::ALIAS,
+            'bin' => self::BIN,
+            'trust' => true,
+        ];
+
+        $command = PhiveInstallCommandFactory::import($properties);
+        $this->assertStringContainsString('trust', (string)$command);
+    }
+
+    public function test_it_accepts_unsigned_phars()
+    {
+        $properties = [
+            'alias' => self::ALIAS,
+            'bin' => self::BIN,
+            'unsigned' => true,
+        ];
+
+        $command = PhiveInstallCommandFactory::import($properties);
+        $this->assertStringContainsString('unsigned', (string)$command);
+    }
+
+    public function provideRequiredProperties(): \Generator
+    {
+        yield ['alias'];
+        yield ['bin'];
+    }
+}

--- a/tests/Json/Factory/PhiveInstallCommandFactoryTest.php
+++ b/tests/Json/Factory/PhiveInstallCommandFactoryTest.php
@@ -10,15 +10,18 @@ class PhiveInstallCommandFactoryTest extends TestCase
 {
     private const ALIAS = 'example/foo';
     private const BIN = '/usr/local/bin/foo';
+    private const SIG = '0000000000000000';
 
     public function test_it_creates_a_command()
     {
         $command = PhiveInstallCommandFactory::import([
             'alias' => self::ALIAS,
             'bin' => self::BIN,
+            'sig' => self::SIG
         ]);
         
         $this->assertInstanceOf(PhiveInstallCommand::class, $command);
+        $this->assertStringNotContainsString('unsigned', (string)$command);
     }
 
     /**
@@ -35,39 +38,15 @@ class PhiveInstallCommandFactoryTest extends TestCase
 
         unset($properties[$property]);
 
-        PhiveInstallCommandFactory::import($properties);
-    }
-
-    public function test_it_accepts_signed_trusted_phars()
-    {
-        $properties = [
-            'alias' => self::ALIAS,
-            'bin' => self::BIN,
-        ];
-
         $command = PhiveInstallCommandFactory::import($properties);
-        $this->assertStringNotContainsString('trust', (string)$command);
-        $this->assertStringNotContainsString('unsigned', (string)$command);
-    }
-
-    public function test_it_accepts_signed_untrusted_phars()
-    {
-        $properties = [
-            'alias' => self::ALIAS,
-            'bin' => self::BIN,
-            'trust' => true,
-        ];
-
-        $command = PhiveInstallCommandFactory::import($properties);
-        $this->assertStringContainsString('trust', (string)$command);
+        $this->assertStringContainsString('unsigned', (string)$command);
     }
 
     public function test_it_accepts_unsigned_phars()
     {
         $properties = [
             'alias' => self::ALIAS,
-            'bin' => self::BIN,
-            'unsigned' => true,
+            'bin' => self::BIN
         ];
 
         $command = PhiveInstallCommandFactory::import($properties);

--- a/tests/Json/Factory/ToolFactoryTest.php
+++ b/tests/Json/Factory/ToolFactoryTest.php
@@ -12,6 +12,7 @@ use Zalas\Toolbox\Tool\Command\ComposerInstallCommand;
 use Zalas\Toolbox\Tool\Command\FileDownloadCommand;
 use Zalas\Toolbox\Tool\Command\MultiStepCommand;
 use Zalas\Toolbox\Tool\Command\PharDownloadCommand;
+use Zalas\Toolbox\Tool\Command\PhiveInstallCommand;
 use Zalas\Toolbox\Tool\Command\ShCommand;
 use Zalas\Toolbox\Tool\Command\TestCommand;
 
@@ -67,6 +68,20 @@ class ToolFactoryTest extends TestCase
         ]));
 
         $this->assertInstanceOf(PharDownloadCommand::class, $tool->command());
+    }
+
+    public function test_it_imports_the_phive_install_command()
+    {
+        $tool = ToolFactory::import($this->definition([
+            'command' => [
+                'phive-install' => [
+                    'alias' => 'phpstan/phpstan',
+                    'bin' => 'tools'
+                ]
+            ]
+        ]));
+
+        $this->assertInstanceOf(PhiveInstallCommand::class, $tool->command());
     }
 
     public function test_it_imports_the_file_download_command()

--- a/tests/Tool/Command/PharDownloadCommandTest.php
+++ b/tests/Tool/Command/PharDownloadCommandTest.php
@@ -11,9 +11,6 @@ class PharDownloadCommandTest extends TestCase
     private const PHAR = 'https://example.com/foo.phar';
     private const BIN = '/usr/local/bin/foo';
 
-    /**
-     * @var FileDownloadCommand
-     */
     private $command;
 
     protected function setUp(): void

--- a/tests/Tool/Command/PhiveInstallCommandTest.php
+++ b/tests/Tool/Command/PhiveInstallCommandTest.php
@@ -1,0 +1,42 @@
+<?php declare(strict_types=1);
+
+namespace Zalas\Toolbox\Tests\Tool\Command;
+
+use PHPUnit\Framework\TestCase;
+use Zalas\Toolbox\Tool\Command;
+use Zalas\Toolbox\Tool\Command\PhiveInstallCommand;
+
+class PhiveInstallCommandTest extends TestCase
+{
+    private const ALIAS = 'example/foo';
+    private const BIN = '/usr/local/bin/foo';
+
+    private $command;
+
+    protected function setUp(): void
+    {
+        $this->command = new PhiveInstallCommand(self::ALIAS, self::BIN);
+    }
+
+    public function test_it_is_a_command()
+    {
+        $this->assertInstanceOf(Command::class, $this->command);
+    }
+
+    public function test_it_generates_the_installation_command()
+    {
+        $this->assertMatchesRegularExpression(\sprintf('#phive install(\s++)--trust-gpg-keys(\s++)%s -t %s#', self::ALIAS, self::BIN), (string) $this->command);
+    }
+
+    public function test_it_trusts_gpg_keys_command()
+    {
+        $command = new PhiveInstallCommand(self::ALIAS, self::BIN, false);
+        $this->assertMatchesRegularExpression(\sprintf('#phive install(\s++)%s -t %s#', self::ALIAS, self::BIN), (string) $command);
+    }
+
+    public function test_it_accepts_unsigned_phar_command()
+    {
+        $command = new PhiveInstallCommand(self::ALIAS, self::BIN, false, true);
+        $this->assertMatchesRegularExpression(\sprintf('#phive install(\s++)--force-accept-unsigned(\s++)%s -t %s#', self::ALIAS, self::BIN), (string) $command);
+    }
+}

--- a/tests/Tool/Command/PhiveInstallCommandTest.php
+++ b/tests/Tool/Command/PhiveInstallCommandTest.php
@@ -26,12 +26,12 @@ class PhiveInstallCommandTest extends TestCase
 
     public function test_it_generates_the_installation_command()
     {
-        $this->assertMatchesRegularExpression(\sprintf('#phive --no-progress --home [^\s]*? install --trust-gpg-keys %s %s -t [^\s]++#', self::SIG, self::ALIAS, self::BIN), (string) $this->command);
+        $this->assertMatchesRegularExpression(\sprintf('#phive --no-progress --home [^\s]*? install --trust-gpg-keys %s %s -t [^\s]++ && mv [^\s]+? %s#', self::SIG, self::ALIAS, self::BIN), (string) $this->command);
     }
 
     public function test_it_accepts_unsigned_phar_command()
     {
         $command = new PhiveInstallCommand(self::ALIAS, self::BIN);
-        $this->assertMatchesRegularExpression(\sprintf('#phive --no-progress --home [^\s]*? install --force-accept-unsigned %s -t [^\s]++#', self::ALIAS, self::BIN), (string) $command);
+        $this->assertMatchesRegularExpression(\sprintf('#phive --no-progress --home [^\s]*? install --force-accept-unsigned %s -t [^\s]++ && mv [^\s]+?#', self::ALIAS, self::BIN), (string) $command);
     }
 }

--- a/tests/Tool/Command/PhiveInstallCommandTest.php
+++ b/tests/Tool/Command/PhiveInstallCommandTest.php
@@ -26,12 +26,12 @@ class PhiveInstallCommandTest extends TestCase
 
     public function test_it_generates_the_installation_command()
     {
-        $this->assertMatchesRegularExpression(\sprintf('#phive --no-progress --home [^\s]*? install --trust-gpg-keys %s %s -t [^\s]++ && mv [^\s]+? %s#', self::SIG, self::ALIAS, self::BIN), (string) $this->command);
+        $this->assertMatchesRegularExpression(\sprintf('#phive --no-progress --home [^\s]*? install --trust-gpg-keys %s %s -t [^\s]++#', self::SIG, self::ALIAS, self::BIN), (string) $this->command);
     }
 
     public function test_it_accepts_unsigned_phar_command()
     {
         $command = new PhiveInstallCommand(self::ALIAS, self::BIN);
-        $this->assertMatchesRegularExpression(\sprintf('#phive --no-progress --home [^\s]*? install --force-accept-unsigned %s -t [^\s]++ && mv [^\s]+?#', self::ALIAS, self::BIN), (string) $command);
+        $this->assertMatchesRegularExpression(\sprintf('#phive --no-progress --home [^\s]*? install --force-accept-unsigned %s -t [^\s]++#', self::ALIAS, self::BIN), (string) $command);
     }
 }

--- a/tests/Tool/Command/PhiveInstallCommandTest.php
+++ b/tests/Tool/Command/PhiveInstallCommandTest.php
@@ -10,12 +10,13 @@ class PhiveInstallCommandTest extends TestCase
 {
     private const ALIAS = 'example/foo';
     private const BIN = '/usr/local/bin/foo';
+    private const SIG = '0000000000000000';
 
     private $command;
 
     protected function setUp(): void
     {
-        $this->command = new PhiveInstallCommand(self::ALIAS, self::BIN);
+        $this->command = new PhiveInstallCommand(self::ALIAS, self::BIN, self::SIG);
     }
 
     public function test_it_is_a_command()
@@ -25,18 +26,12 @@ class PhiveInstallCommandTest extends TestCase
 
     public function test_it_generates_the_installation_command()
     {
-        $this->assertMatchesRegularExpression(\sprintf('#phive install(\s++)--trust-gpg-keys(\s++)%s -t %s#', self::ALIAS, self::BIN), (string) $this->command);
-    }
-
-    public function test_it_trusts_gpg_keys_command()
-    {
-        $command = new PhiveInstallCommand(self::ALIAS, self::BIN, false);
-        $this->assertMatchesRegularExpression(\sprintf('#phive install(\s++)%s -t %s#', self::ALIAS, self::BIN), (string) $command);
+        $this->assertMatchesRegularExpression(\sprintf('#phive --no-progress --home [^\s]*? install --trust-gpg-keys %s %s -t [^\s]++ && mv [^\s]+? %s#', self::SIG, self::ALIAS, self::BIN), (string) $this->command);
     }
 
     public function test_it_accepts_unsigned_phar_command()
     {
-        $command = new PhiveInstallCommand(self::ALIAS, self::BIN, false, true);
-        $this->assertMatchesRegularExpression(\sprintf('#phive install(\s++)--force-accept-unsigned(\s++)%s -t %s#', self::ALIAS, self::BIN), (string) $command);
+        $command = new PhiveInstallCommand(self::ALIAS, self::BIN);
+        $this->assertMatchesRegularExpression(\sprintf('#phive --no-progress --home [^\s]*? install --force-accept-unsigned %s -t [^\s]++ && mv [^\s]+?#', self::ALIAS, self::BIN), (string) $command);
     }
 }

--- a/tests/UseCase/InstallToolsTest.php
+++ b/tests/UseCase/InstallToolsTest.php
@@ -167,7 +167,7 @@ class InstallToolsTest extends TestCase
         ]));
 
         $command = $this->useCase->__invoke($this->filter());
-        $this->assertMatchesRegularExpression('#phive --no-progress --home /tools install[^&]*?phpunit[^&]*? [^\s]++ && mv [^\s]++ /tools/phpunit#', (string)$command);
+        $this->assertMatchesRegularExpression('#phive --no-progress --home /tools/.phive install[^&]*?phpunit[^&]*? [^\s]++#', (string)$command);
     }
 
     public function test_it_includes_file_download_commands()

--- a/tests/UseCase/InstallToolsTest.php
+++ b/tests/UseCase/InstallToolsTest.php
@@ -15,6 +15,7 @@ use Zalas\Toolbox\Tool\Command\ComposerInstallCommand;
 use Zalas\Toolbox\Tool\Command\FileDownloadCommand;
 use Zalas\Toolbox\Tool\Command\MultiStepCommand;
 use Zalas\Toolbox\Tool\Command\PharDownloadCommand;
+use Zalas\Toolbox\Tool\Command\PhiveInstallCommand;
 use Zalas\Toolbox\Tool\Command\ShCommand;
 use Zalas\Toolbox\Tool\Filter;
 use Zalas\Toolbox\Tool\Tool;
@@ -157,6 +158,17 @@ class InstallToolsTest extends TestCase
         $command = $this->useCase->__invoke($this->filter());
 
         $this->assertMatchesRegularExpression('#curl[^&]*?deptrac-0.2.0.phar#', (string)$command);
+    }
+
+    public function test_it_includes_phive_install_commands()
+    {
+        $this->tools->all(Argument::type(Filter::class))->willReturn(Collection::create([
+            $this->tool(new PhiveInstallCommand('phpunit', '/tools/phpunit')),
+        ]));
+
+        $command = $this->useCase->__invoke($this->filter());
+
+        $this->assertMatchesRegularExpression('#phive install[^&]*?phpunit[^&]*?/tools/phpunit#', (string)$command);
     }
 
     public function test_it_includes_file_download_commands()

--- a/tests/UseCase/InstallToolsTest.php
+++ b/tests/UseCase/InstallToolsTest.php
@@ -167,7 +167,7 @@ class InstallToolsTest extends TestCase
         ]));
 
         $command = $this->useCase->__invoke($this->filter());
-        $this->assertMatchesRegularExpression('#phive --no-progress --home /tools/.phive install[^&]*?phpunit[^&]*? [^\s]++#', (string)$command);
+        $this->assertMatchesRegularExpression('#phive --no-progress --home /tools/.phive install[^&]*?phpunit[^&]*? [^\s]++ && mv [^\s]++ /tools/phpunit#', (string)$command);
     }
 
     public function test_it_includes_file_download_commands()

--- a/tests/UseCase/InstallToolsTest.php
+++ b/tests/UseCase/InstallToolsTest.php
@@ -167,8 +167,7 @@ class InstallToolsTest extends TestCase
         ]));
 
         $command = $this->useCase->__invoke($this->filter());
-
-        $this->assertMatchesRegularExpression('#phive install[^&]*?phpunit[^&]*?/tools/phpunit#', (string)$command);
+        $this->assertMatchesRegularExpression('#phive --no-progress --home /tools install[^&]*?phpunit[^&]*? [^\s]++ && mv [^\s]++ /tools/phpunit#', (string)$command);
     }
 
     public function test_it_includes_file_download_commands()


### PR DESCRIPTION
Based on #354 I've migrated all the `phar-download` commands to `phive-install` commands.

Some didn't work tho, idk why.

Note: if the tool was installed with a specific version in the url, then I retained the version specification in the install command (`alias@^version`). Most tools likely didn't have a `latest` url setup so the version is probably unnecessary there (it's not a BC break) but I can't know that.