### PR TITLE
Add composer-require-checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ It has been extracted as a separate project to make maintenance easier and enabl
 | composer | [Dependency Manager for PHP](https://getcomposer.org/) | &#x2705; | &#x2705; | &#x2705; |
 | composer-bin-plugin | [Composer plugin to install bin vendors in isolated locations](https://github.com/bamarni/composer-bin-plugin) | &#x2705; | &#x2705; | &#x2705; |
 | composer-normalize | [Composer plugin to normalize composer.json files](https://github.com/ergebnis/composer-normalize) | &#x2705; | &#x2705; | &#x2705; |
+| composer-require-checker | [Verify that no unknown symbols are used in the sources of a package.](https://github.com/maglnet/ComposerRequireChecker) | &#x274C; | &#x2705; | &#x2705; |
+| composer-require-checker-v2 | [Verify that no unknown symbols are used in the sources of a package.](https://github.com/maglnet/ComposerRequireChecker) | &#x2705; | &#x2705; | &#x2705; |
 | composer-unused | [Show unused packages by scanning your code](https://github.com/icanhazstring/composer-unused) | &#x2705; | &#x2705; | &#x2705; |
 | dephpend | [Detect flaws in your architecture](https://dephpend.com/) | &#x2705; | &#x2705; | &#x2705; |
 | deprecation-detector | [Finds usages of deprecated code](https://github.com/sensiolabs-de/deprecation-detector) | &#x2705; | &#x2705; | &#x2705; |

--- a/resources/composer.json
+++ b/resources/composer.json
@@ -24,6 +24,40 @@
             },
             "test": "composer-unused -vvv | grep 'Your system is ready'",
             "tags": ["composer"]
+        },
+        {
+            "name": "composer-require-checker",
+            "summary": "Verify that no unknown symbols are used in the sources of a package.",
+            "website": "https://github.com/maglnet/ComposerRequireChecker",
+            "command": {
+                "file-download": {
+                    "url": "https://github.com/maglnet/ComposerRequireChecker/releases/download/3.1.0/composer-require-checker.phar.asc",
+                    "file": "%target-dir%/composer-require-checker.asc"
+                },
+                "phar-download": {
+                    "phar": "https://github.com/maglnet/ComposerRequireChecker/releases/download/3.1.0/composer-require-checker.phar",
+                    "bin": "%target-dir%/composer-require-checker"
+                }
+            },
+            "test": "composer-require-checker -V",
+            "tags": ["exclude-php:7.3", "composer"]
+        },
+        {
+            "name": "composer-require-checker-v2",
+            "summary": "Verify that no unknown symbols are used in the sources of a package.",
+            "website": "https://github.com/maglnet/ComposerRequireChecker",
+            "command": {
+                "file-download": {
+                    "url": "https://github.com/maglnet/ComposerRequireChecker/releases/download/2.1.0/composer-require-checker.phar.asc",
+                    "file": "%target-dir%/composer-require-checker-v2.asc"
+                },
+                "phar-download": {
+                    "phar": "https://github.com/maglnet/ComposerRequireChecker/releases/download/2.1.0/composer-require-checker.phar",
+                    "bin": "%target-dir%/composer-require-checker-v2"
+                }
+            },
+            "test": "composer-require-checker-v2 -V",
+            "tags": ["composer"]
         }
     ]
 }


### PR DESCRIPTION
Adds [composer-require-checker](https://github.com/maglnet/ComposerRequireChecker).

I removed the `phive` dependency because it looks like that will need a bit more work.