### PR TITLE
Enable phpmnd on PHP8

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ It has been extracted as a separate project to make maintenance easier and enabl
 | phploc | [A tool for quickly measuring the size of a PHP project](https://github.com/sebastianbergmann/phploc) | &#x2705; | &#x2705; | &#x2705; |
 | phpmd | [A tool for finding problems in PHP code](https://phpmd.org/) | &#x2705; | &#x2705; | &#x2705; |
 | phpmetrics | [Static Analysis Tool](http://www.phpmetrics.org/) | &#x2705; | &#x2705; | &#x2705; |
-| phpmnd | [Helps to detect magic numbers](https://github.com/povils/phpmnd) | &#x2705; | &#x2705; | &#x274C; |
+| phpmnd | [Helps to detect magic numbers](https://github.com/povils/phpmnd) | &#x2705; | &#x2705; | &#x2705; |
 | phpspec | [SpecBDD Framework](http://www.phpspec.net/) | &#x2705; | &#x2705; | &#x2705; |
 | phpstan | [Static Analysis Tool](https://github.com/phpstan/phpstan) | &#x2705; | &#x2705; | &#x2705; |
 | phpstan-beberlei-assert | [PHPStan extension for beberlei/assert](https://github.com/phpstan/phpstan-beberlei-assert) | &#x2705; | &#x2705; | &#x2705; |

--- a/resources/tools.json
+++ b/resources/tools.json
@@ -107,8 +107,7 @@
           "links": {"%target-dir%/phpmnd": "phpmnd"}
         }
       },
-      "test": "phpmnd -V",
-      "tags": ["exclude-php:8.0"]
+      "test": "phpmnd -V"
     }
   ]
 }


### PR DESCRIPTION
Phpmnd released new version wich support PHP8.
See #357

https://github.com/povils/phpmnd/releases/tag/v2.4.0