### PR TITLE
Switch to the main rector respository

### DIFF
--- a/resources/refactoring.json
+++ b/resources/refactoring.json
@@ -33,7 +33,7 @@
             "website": "https://github.com/rectorphp/rector",
             "command": {
                 "composer-bin-plugin": {
-                    "package": "rector/rector-prefixed",
+                    "package": "rector/rector",
                     "namespace": "rector",
                     "links": {"%target-dir%/rector": "rector"}
                 }


### PR DESCRIPTION
it is now prefixed by default: https://getrector.org/blog/prefixed-rector-by-default

re https://github.com/jakzal/phpqa/issues/324
