### PR TITLE
Drop support for PHP 7.3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,10 +18,10 @@ jobs:
         name: Build and test
         strategy:
             matrix:
-                php: [7.3, 7.4, 8.0]
+                php: [7.4, 8.0]
                 deps: [high]
                 include:
-                    -   php: 7.3
+                    -   php: 7.4
                         deps: low
 
         steps:
@@ -42,13 +42,13 @@ jobs:
                 run: make update-min test-min
 
             -   uses: actions/upload-artifact@v1
-                if: matrix.php == '7.3' && matrix.deps == 'high'
+                if: matrix.php == '7.4' && matrix.deps == 'high'
                 with:
                     name: toolbox.phar
                     path: build/toolbox.phar
 
             -   uses: actions/upload-artifact@v1
-                if: matrix.php == '7.3' && matrix.deps == 'high'
+                if: matrix.php == '7.4' && matrix.deps == 'high'
                 with:
                     name: devkit.phar
                     path: build/devkit.phar
@@ -59,7 +59,7 @@ jobs:
         needs: tests
         strategy:
             matrix:
-                php: [7.3, 7.4, 8.0]
+                php: [7.4, 8.0]
 
         steps:
             -   uses: actions/checkout@v2

--- a/Makefile
+++ b/Makefile
@@ -137,8 +137,8 @@ tools/php-cs-fixer:
 	curl -Ls https://cs.symfony.com/download/php-cs-fixer-v3.phar -o tools/php-cs-fixer && chmod +x tools/php-cs-fixer
 
 tools/deptrac:
-	curl -Ls https://github.com/qossmic/deptrac/releases/download/0.14.0/deptrac.phar -o tools/deptrac && chmod +x tools/deptrac
-	curl -Ls https://github.com/qossmic/deptrac/releases/download/0.14.0/deptrac.phar.asc -o tools/deptrac.asc
+	curl -Ls https://github.com/qossmic/deptrac/releases/download/0.18.0/deptrac.phar -o tools/deptrac && chmod +x tools/deptrac
+	curl -Ls https://github.com/qossmic/deptrac/releases/download/0.18.0/deptrac.phar.asc -o tools/deptrac.asc
 
 tools/box:
 	curl -Ls https://github.com/humbug/box/releases/download/3.13.0/box.phar -o tools/box && chmod +x tools/box

--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ package: tools/box
 	sed -e 's/Application('"'"'dev/Application('"'"'$(TOOLBOX_VERSION)/g' bin/toolbox.php > build/phar/bin/toolbox.php
 
 	cd build/phar && \
-	  composer config platform.php 7.4 && \
+	  composer config platform.php 7.4.7 && \
 	  composer update --no-dev -o -a
 
 	tools/box compile
@@ -83,7 +83,7 @@ package-devkit: tools/box
 	sed -e 's/\(Application(.*\)'"'"'dev/\1'"'"'$(TOOLBOX_VERSION)/g' bin/devkit.php > build/devkit-phar/bin/devkit.php
 
 	cd build/devkit-phar && \
-	  composer config platform.php 7.4 && \
+	  composer config platform.php 7.4.7 && \
 	  composer update --no-dev -o -a
 
 	tools/box compile -c box-devkit.json.dist

--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ package: tools/box
 	sed -e 's/Application('"'"'dev/Application('"'"'$(TOOLBOX_VERSION)/g' bin/toolbox.php > build/phar/bin/toolbox.php
 
 	cd build/phar && \
-	  composer config platform.php 7.3 && \
+	  composer config platform.php 7.4 && \
 	  composer update --no-dev -o -a
 
 	tools/box compile
@@ -83,7 +83,7 @@ package-devkit: tools/box
 	sed -e 's/\(Application(.*\)'"'"'dev/\1'"'"'$(TOOLBOX_VERSION)/g' bin/devkit.php > build/devkit-phar/bin/devkit.php
 
 	cd build/devkit-phar && \
-	  composer config platform.php 7.3 && \
+	  composer config platform.php 7.4 && \
 	  composer update --no-dev -o -a
 
 	tools/box compile -c box-devkit.json.dist

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ It has been extracted as a separate project to make maintenance easier and enabl
 ## Available tools
 
 | Name | Description | PHP 7.4 | PHP 8.0
-| :--- | :---------- | :------ | :------ | :------
+| :--- | :---------- | :------ | :------
 | analyze | [Visualizes metrics and source code](https://github.com/Qafoo/QualityAnalyzer) | &#x2705; | &#x274C; |
 | behat | [Helps to test business expectations](http://behat.org/) | &#x2705; | &#x2705; |
 | box | [Fast, zero config application bundler with PHARs](https://github.com/humbug/box) | &#x2705; | &#x2705; |

--- a/README.md
+++ b/README.md
@@ -14,86 +14,85 @@ It has been extracted as a separate project to make maintenance easier and enabl
 
 ## Available tools
 
-| Name | Description | PHP 7.3 | PHP 7.4 | PHP 8.0
+| Name | Description | PHP 7.4 | PHP 8.0
 | :--- | :---------- | :------ | :------ | :------
-| analyze | [Visualizes metrics and source code](https://github.com/Qafoo/QualityAnalyzer) | &#x2705; | &#x2705; | &#x274C; |
-| behat | [Helps to test business expectations](http://behat.org/) | &#x2705; | &#x2705; | &#x2705; |
-| box | [Fast, zero config application bundler with PHARs](https://github.com/humbug/box) | &#x2705; | &#x2705; | &#x2705; |
-| box-legacy | [Legacy version of box](https://box-project.github.io/box2/) | &#x2705; | &#x2705; | &#x2705; |
-| churn | [Discovers good candidates for refactoring](https://github.com/bmitch/churn-php) | &#x2705; | &#x2705; | &#x2705; |
-| codeception | [Codeception is a BDD-styled PHP testing framework](https://codeception.com/) | &#x2705; | &#x2705; | &#x2705; |
-| composer | [Dependency Manager for PHP](https://getcomposer.org/) | &#x2705; | &#x2705; | &#x2705; |
-| composer-bin-plugin | [Composer plugin to install bin vendors in isolated locations](https://github.com/bamarni/composer-bin-plugin) | &#x2705; | &#x2705; | &#x2705; |
-| composer-normalize | [Composer plugin to normalize composer.json files](https://github.com/ergebnis/composer-normalize) | &#x2705; | &#x2705; | &#x2705; |
-| composer-require-checker | [Verify that no unknown symbols are used in the sources of a package.](https://github.com/maglnet/ComposerRequireChecker) | &#x274C; | &#x2705; | &#x2705; |
-| composer-require-checker-v2 | [Verify that no unknown symbols are used in the sources of a package.](https://github.com/maglnet/ComposerRequireChecker) | &#x2705; | &#x274C; | &#x274C; |
-| composer-unused | [Show unused packages by scanning your code](https://github.com/icanhazstring/composer-unused) | &#x2705; | &#x2705; | &#x2705; |
-| dephpend | [Detect flaws in your architecture](https://dephpend.com/) | &#x2705; | &#x2705; | &#x2705; |
-| deprecation-detector | [Finds usages of deprecated code](https://github.com/sensiolabs-de/deprecation-detector) | &#x2705; | &#x2705; | &#x2705; |
-| deptrac | [Enforces dependency rules between software layers](https://github.com/qossmic/deptrac) | &#x274C; | &#x2705; | &#x2705; |
-| diffFilter | [Applies QA tools to run on a single pull request](https://github.com/exussum12/coverageChecker) | &#x2705; | &#x2705; | &#x2705; |
-| ecs | [Sets up and runs coding standard checks](https://github.com/Symplify/EasyCodingStandard) | &#x2705; | &#x2705; | &#x2705; |
-| infection | [AST based PHP Mutation Testing Framework](https://infection.github.io/) | &#x274C; | &#x2705; | &#x2705; |
-| larastan | [PHPStan extension for Laravel](https://github.com/nunomaduro/larastan) | &#x2705; | &#x2705; | &#x2705; |
-| local-php-security-checker | [Checks composer dependencies for known security vulnerabilities](https://github.com/fabpot/local-php-security-checker) | &#x2705; | &#x2705; | &#x2705; |
-| parallel-lint | [Checks PHP file syntax](https://github.com/php-parallel-lint/PHP-Parallel-Lint) | &#x2705; | &#x2705; | &#x2705; |
-| paratest | [Parallel testing for PHPUnit](https://github.com/paratestphp/paratest) | &#x2705; | &#x2705; | &#x2705; |
-| pdepend | [Static Analysis Tool](https://pdepend.org/) | &#x2705; | &#x2705; | &#x2705; |
-| phan | [Static Analysis Tool](https://github.com/phan/phan) | &#x2705; | &#x2705; | &#x2705; |
-| phive | [PHAR Installation and Verification Environment](https://phar.io/) | &#x2705; | &#x2705; | &#x2705; |
-| php-coupling-detector | [Detects code coupling issues](https://akeneo.github.io/php-coupling-detector/) | &#x2705; | &#x2705; | &#x2705; |
-| php-cs-fixer | [PHP Coding Standards Fixer](http://cs.symfony.com/) | &#x2705; | &#x2705; | &#x2705; |
-| php-formatter | [Custom coding standards fixer](https://github.com/mmoreram/php-formatter) | &#x2705; | &#x2705; | &#x274C; |
-| php-fuzzer | [A fuzzer for PHP, which can be used to find bugs in libraries by feeding them 'random' inputs](https://github.com/nikic/PHP-Fuzzer) | &#x274C; | &#x2705; | &#x2705; |
-| php-semver-checker | [Suggests a next version according to semantic versioning](https://github.com/tomzx/php-semver-checker) | &#x2705; | &#x2705; | &#x2705; |
-| phpa | [Checks for weak assumptions](https://github.com/rskuipers/php-assumptions) | &#x2705; | &#x2705; | &#x2705; |
-| phpat | [Easy to use architecture testing tool](https://github.com/carlosas/phpat) | &#x2705; | &#x2705; | &#x274C; |
-| phpbench | [PHP Benchmarking framework](https://github.com/phpbench/phpbench) | &#x2705; | &#x2705; | &#x2705; |
-| phpca | [Finds usage of non-built-in extensions](https://github.com/wapmorgan/PhpCodeAnalyzer) | &#x2705; | &#x2705; | &#x2705; |
-| phpcb | [PHP Code Browser](https://github.com/mayflower/PHP_CodeBrowser) | &#x2705; | &#x2705; | &#x2705; |
-| phpcbf | [Automatically corrects coding standard violations](https://github.com/squizlabs/PHP_CodeSniffer) | &#x2705; | &#x2705; | &#x2705; |
-| phpcodesniffer-composer-install | [Easy installation of PHP_CodeSniffer coding standards (rulesets).](https://github.com/Dealerdirect/phpcodesniffer-composer-installer) | &#x2705; | &#x2705; | &#x2705; |
-| phpcov | [a command-line frontend for the PHP_CodeCoverage library](https://github.com/sebastianbergmann/phpcov) | &#x2705; | &#x2705; | &#x2705; |
-| phpcpd | [Copy/Paste Detector](https://github.com/sebastianbergmann/phpcpd) | &#x2705; | &#x2705; | &#x2705; |
-| phpcs | [Detects coding standard violations](https://github.com/squizlabs/PHP_CodeSniffer) | &#x2705; | &#x2705; | &#x2705; |
-| phpcs-security-audit | [Finds vulnerabilities and weaknesses related to security in PHP code](https://github.com/FloeDesignTechnologies/phpcs-security-audit) | &#x2705; | &#x2705; | &#x2705; |
-| phpda | [Generates dependency graphs](https://mamuz.github.io/PhpDependencyAnalysis/) | &#x2705; | &#x2705; | &#x2705; |
-| phpdd | [Finds usage of deprecated features](http://wapmorgan.github.io/PhpDeprecationDetector) | &#x2705; | &#x2705; | &#x2705; |
-| phpdoc-to-typehint | [Automatically adds type hints and return types based on PHPDocs](https://github.com/dunglas/phpdoc-to-typehint) | &#x2705; | &#x2705; | &#x2705; |
-| phpDocumentor | [Documentation generator](https://www.phpdoc.org/) | &#x2705; | &#x2705; | &#x2705; |
-| phpinsights | [Analyses code quality, style, architecture and complexity](https://phpinsights.com/) | &#x2705; | &#x2705; | &#x2705; |
-| phplint | [Lints php files in parallel](https://github.com/overtrue/phplint) | &#x274C; | &#x2705; | &#x2705; |
-| phploc | [A tool for quickly measuring the size of a PHP project](https://github.com/sebastianbergmann/phploc) | &#x2705; | &#x2705; | &#x2705; |
-| phpmd | [A tool for finding problems in PHP code](https://phpmd.org/) | &#x2705; | &#x2705; | &#x2705; |
-| phpmetrics | [Static Analysis Tool](http://www.phpmetrics.org/) | &#x2705; | &#x2705; | &#x2705; |
-| phpmnd | [Helps to detect magic numbers](https://github.com/povils/phpmnd) | &#x2705; | &#x2705; | &#x2705; |
-| phpspec | [SpecBDD Framework](http://www.phpspec.net/) | &#x2705; | &#x2705; | &#x2705; |
-| phpstan | [Static Analysis Tool](https://github.com/phpstan/phpstan) | &#x2705; | &#x2705; | &#x2705; |
-| phpstan-beberlei-assert | [PHPStan extension for beberlei/assert](https://github.com/phpstan/phpstan-beberlei-assert) | &#x2705; | &#x2705; | &#x2705; |
-| phpstan-deprecation-rules | [PHPStan rules for detecting deprecated code](https://github.com/phpstan/phpstan-deprecation-rules) | &#x2705; | &#x2705; | &#x2705; |
-| phpstan-doctrine | [Doctrine extensions for PHPStan](https://github.com/phpstan/phpstan-doctrine) | &#x2705; | &#x2705; | &#x2705; |
-| phpstan-ergebnis-rules | [Additional rules for PHPstan](https://github.com/ergebnis/phpstan-rules) | &#x2705; | &#x2705; | &#x2705; |
-| phpstan-exception-rules | [PHPStan rules for checked and unchecked exceptions](https://github.com/pepakriz/phpstan-exception-rules) | &#x2705; | &#x2705; | &#x2705; |
-| phpstan-larastan | [Separate installation of phpstan for larastan](https://github.com/phpstan/phpstan) | &#x2705; | &#x2705; | &#x2705; |
-| phpstan-phpunit | [PHPUnit extensions and rules for PHPStan](https://github.com/phpstan/phpstan-phpunit) | &#x2705; | &#x2705; | &#x2705; |
-| phpstan-strict-rules | [Extra strict and opinionated rules for PHPStan](https://github.com/phpstan/phpstan-strict-rules) | &#x2705; | &#x2705; | &#x2705; |
-| phpstan-symfony | [Symfony extension for PHPStan](https://github.com/phpstan/phpstan-symfony) | &#x2705; | &#x2705; | &#x2705; |
-| phpstan-webmozart-assert | [PHPStan extension for webmozart/assert](https://github.com/phpstan/phpstan-webmozart-assert) | &#x2705; | &#x2705; | &#x2705; |
-| phpunit | [The PHP testing framework](https://phpunit.de/) | &#x2705; | &#x2705; | &#x2705; |
-| phpunit-5 | [The PHP testing framework (5.x version)](https://phpunit.de/) | &#x2705; | &#x2705; | &#x274C; |
-| phpunit-7 | [The PHP testing framework (7.x version)](https://phpunit.de/) | &#x2705; | &#x2705; | &#x274C; |
-| phpunit-8 | [The PHP testing framework (8.x version)](https://phpunit.de/) | &#x2705; | &#x2705; | &#x2705; |
-| psalm | [Finds errors in PHP applications](https://psalm.dev/) | &#x2705; | &#x2705; | &#x2705; |
-| psalm-plugin-doctrine | [Stubs to let Psalm understand Doctrine better](https://github.com/weirdan/doctrine-psalm-plugin) | &#x2705; | &#x2705; | &#x2705; |
-| psalm-plugin-phpunit | [Psalm plugin for PHPUnit](https://github.com/psalm/psalm-plugin-phpunit) | &#x2705; | &#x2705; | &#x2705; |
-| psalm-plugin-symfony | [Psalm Plugin for Symfony](https://github.com/psalm/psalm-plugin-symfony) | &#x2705; | &#x2705; | &#x2705; |
-| psecio-parse | [Scans code for potential security-related issues](https://github.com/psecio/parse) | &#x2705; | &#x2705; | &#x2705; |
-| rector | [Tool for instant code upgrades and refactoring](https://github.com/rectorphp/rector) | &#x2705; | &#x2705; | &#x2705; |
-| roave-backward-compatibility-check | [Tool to compare two revisions of a class API to check for BC breaks](https://github.com/Roave/BackwardCompatibilityCheck) | &#x274C; | &#x2705; | &#x274C; |
-| simple-phpunit | [Provides utilities to report legacy tests and usage of deprecated code](https://symfony.com/doc/current/components/phpunit_bridge.html) | &#x2705; | &#x2705; | &#x2705; |
-| twig-lint | [Standalone twig linter](https://github.com/asm89/twig-lint) | &#x2705; | &#x2705; | &#x2705; |
-| twigcs | [The missing checkstyle for twig!](https://github.com/friendsoftwig/twigcs) | &#x2705; | &#x2705; | &#x2705; |
-| yaml-lint | [Compact command line utility for checking YAML file syntax](https://github.com/j13k/yaml-lint) | &#x2705; | &#x2705; | &#x2705; |
+| analyze | [Visualizes metrics and source code](https://github.com/Qafoo/QualityAnalyzer) | &#x2705; | &#x274C; |
+| behat | [Helps to test business expectations](http://behat.org/) | &#x2705; | &#x2705; |
+| box | [Fast, zero config application bundler with PHARs](https://github.com/humbug/box) | &#x2705; | &#x2705; |
+| box-legacy | [Legacy version of box](https://box-project.github.io/box2/) | &#x2705; | &#x2705; |
+| churn | [Discovers good candidates for refactoring](https://github.com/bmitch/churn-php) | &#x2705; | &#x2705; |
+| codeception | [Codeception is a BDD-styled PHP testing framework](https://codeception.com/) | &#x2705; | &#x2705; |
+| composer | [Dependency Manager for PHP](https://getcomposer.org/) | &#x2705; | &#x2705; |
+| composer-bin-plugin | [Composer plugin to install bin vendors in isolated locations](https://github.com/bamarni/composer-bin-plugin) | &#x2705; | &#x2705; |
+| composer-normalize | [Composer plugin to normalize composer.json files](https://github.com/ergebnis/composer-normalize) | &#x2705; | &#x2705; |
+| composer-require-checker | [Verify that no unknown symbols are used in the sources of a package.](https://github.com/maglnet/ComposerRequireChecker) | &#x2705; | &#x2705; |
+| composer-unused | [Show unused packages by scanning your code](https://github.com/icanhazstring/composer-unused) | &#x2705; | &#x2705; |
+| dephpend | [Detect flaws in your architecture](https://dephpend.com/) | &#x2705; | &#x2705; |
+| deprecation-detector | [Finds usages of deprecated code](https://github.com/sensiolabs-de/deprecation-detector) | &#x2705; | &#x2705; |
+| deptrac | [Enforces dependency rules between software layers](https://github.com/qossmic/deptrac) | &#x2705; | &#x2705; |
+| diffFilter | [Applies QA tools to run on a single pull request](https://github.com/exussum12/coverageChecker) | &#x2705; | &#x2705; |
+| ecs | [Sets up and runs coding standard checks](https://github.com/Symplify/EasyCodingStandard) | &#x2705; | &#x2705; |
+| infection | [AST based PHP Mutation Testing Framework](https://infection.github.io/) | &#x2705; | &#x2705; |
+| larastan | [PHPStan extension for Laravel](https://github.com/nunomaduro/larastan) | &#x2705; | &#x2705; |
+| local-php-security-checker | [Checks composer dependencies for known security vulnerabilities](https://github.com/fabpot/local-php-security-checker) | &#x2705; | &#x2705; |
+| parallel-lint | [Checks PHP file syntax](https://github.com/php-parallel-lint/PHP-Parallel-Lint) | &#x2705; | &#x2705; |
+| paratest | [Parallel testing for PHPUnit](https://github.com/paratestphp/paratest) | &#x2705; | &#x2705; |
+| pdepend | [Static Analysis Tool](https://pdepend.org/) | &#x2705; | &#x2705; |
+| phan | [Static Analysis Tool](https://github.com/phan/phan) | &#x2705; | &#x2705; |
+| phive | [PHAR Installation and Verification Environment](https://phar.io/) | &#x2705; | &#x2705; |
+| php-coupling-detector | [Detects code coupling issues](https://akeneo.github.io/php-coupling-detector/) | &#x2705; | &#x2705; |
+| php-cs-fixer | [PHP Coding Standards Fixer](http://cs.symfony.com/) | &#x2705; | &#x2705; |
+| php-formatter | [Custom coding standards fixer](https://github.com/mmoreram/php-formatter) | &#x2705; | &#x274C; |
+| php-fuzzer | [A fuzzer for PHP, which can be used to find bugs in libraries by feeding them 'random' inputs](https://github.com/nikic/PHP-Fuzzer) | &#x2705; | &#x2705; |
+| php-semver-checker | [Suggests a next version according to semantic versioning](https://github.com/tomzx/php-semver-checker) | &#x2705; | &#x2705; |
+| phpa | [Checks for weak assumptions](https://github.com/rskuipers/php-assumptions) | &#x2705; | &#x2705; |
+| phpat | [Easy to use architecture testing tool](https://github.com/carlosas/phpat) | &#x2705; | &#x274C; |
+| phpbench | [PHP Benchmarking framework](https://github.com/phpbench/phpbench) | &#x2705; | &#x2705; |
+| phpca | [Finds usage of non-built-in extensions](https://github.com/wapmorgan/PhpCodeAnalyzer) | &#x2705; | &#x2705; |
+| phpcb | [PHP Code Browser](https://github.com/mayflower/PHP_CodeBrowser) | &#x2705; | &#x2705; |
+| phpcbf | [Automatically corrects coding standard violations](https://github.com/squizlabs/PHP_CodeSniffer) | &#x2705; | &#x2705; |
+| phpcodesniffer-composer-install | [Easy installation of PHP_CodeSniffer coding standards (rulesets).](https://github.com/Dealerdirect/phpcodesniffer-composer-installer) | &#x2705; | &#x2705; |
+| phpcov | [a command-line frontend for the PHP_CodeCoverage library](https://github.com/sebastianbergmann/phpcov) | &#x2705; | &#x2705; |
+| phpcpd | [Copy/Paste Detector](https://github.com/sebastianbergmann/phpcpd) | &#x2705; | &#x2705; |
+| phpcs | [Detects coding standard violations](https://github.com/squizlabs/PHP_CodeSniffer) | &#x2705; | &#x2705; |
+| phpcs-security-audit | [Finds vulnerabilities and weaknesses related to security in PHP code](https://github.com/FloeDesignTechnologies/phpcs-security-audit) | &#x2705; | &#x2705; |
+| phpda | [Generates dependency graphs](https://mamuz.github.io/PhpDependencyAnalysis/) | &#x2705; | &#x2705; |
+| phpdd | [Finds usage of deprecated features](http://wapmorgan.github.io/PhpDeprecationDetector) | &#x2705; | &#x2705; |
+| phpdoc-to-typehint | [Automatically adds type hints and return types based on PHPDocs](https://github.com/dunglas/phpdoc-to-typehint) | &#x2705; | &#x2705; |
+| phpDocumentor | [Documentation generator](https://www.phpdoc.org/) | &#x2705; | &#x2705; |
+| phpinsights | [Analyses code quality, style, architecture and complexity](https://phpinsights.com/) | &#x2705; | &#x2705; |
+| phplint | [Lints php files in parallel](https://github.com/overtrue/phplint) | &#x2705; | &#x2705; |
+| phploc | [A tool for quickly measuring the size of a PHP project](https://github.com/sebastianbergmann/phploc) | &#x2705; | &#x2705; |
+| phpmd | [A tool for finding problems in PHP code](https://phpmd.org/) | &#x2705; | &#x2705; |
+| phpmetrics | [Static Analysis Tool](http://www.phpmetrics.org/) | &#x2705; | &#x2705; |
+| phpmnd | [Helps to detect magic numbers](https://github.com/povils/phpmnd) | &#x2705; | &#x2705; |
+| phpspec | [SpecBDD Framework](http://www.phpspec.net/) | &#x2705; | &#x2705; |
+| phpstan | [Static Analysis Tool](https://github.com/phpstan/phpstan) | &#x2705; | &#x2705; |
+| phpstan-beberlei-assert | [PHPStan extension for beberlei/assert](https://github.com/phpstan/phpstan-beberlei-assert) | &#x2705; | &#x2705; |
+| phpstan-deprecation-rules | [PHPStan rules for detecting deprecated code](https://github.com/phpstan/phpstan-deprecation-rules) | &#x2705; | &#x2705; |
+| phpstan-doctrine | [Doctrine extensions for PHPStan](https://github.com/phpstan/phpstan-doctrine) | &#x2705; | &#x2705; |
+| phpstan-ergebnis-rules | [Additional rules for PHPstan](https://github.com/ergebnis/phpstan-rules) | &#x2705; | &#x2705; |
+| phpstan-exception-rules | [PHPStan rules for checked and unchecked exceptions](https://github.com/pepakriz/phpstan-exception-rules) | &#x2705; | &#x2705; |
+| phpstan-larastan | [Separate installation of phpstan for larastan](https://github.com/phpstan/phpstan) | &#x2705; | &#x2705; |
+| phpstan-phpunit | [PHPUnit extensions and rules for PHPStan](https://github.com/phpstan/phpstan-phpunit) | &#x2705; | &#x2705; |
+| phpstan-strict-rules | [Extra strict and opinionated rules for PHPStan](https://github.com/phpstan/phpstan-strict-rules) | &#x2705; | &#x2705; |
+| phpstan-symfony | [Symfony extension for PHPStan](https://github.com/phpstan/phpstan-symfony) | &#x2705; | &#x2705; |
+| phpstan-webmozart-assert | [PHPStan extension for webmozart/assert](https://github.com/phpstan/phpstan-webmozart-assert) | &#x2705; | &#x2705; |
+| phpunit | [The PHP testing framework](https://phpunit.de/) | &#x2705; | &#x2705; |
+| phpunit-5 | [The PHP testing framework (5.x version)](https://phpunit.de/) | &#x2705; | &#x274C; |
+| phpunit-7 | [The PHP testing framework (7.x version)](https://phpunit.de/) | &#x2705; | &#x274C; |
+| phpunit-8 | [The PHP testing framework (8.x version)](https://phpunit.de/) | &#x2705; | &#x2705; |
+| psalm | [Finds errors in PHP applications](https://psalm.dev/) | &#x2705; | &#x2705; |
+| psalm-plugin-doctrine | [Stubs to let Psalm understand Doctrine better](https://github.com/weirdan/doctrine-psalm-plugin) | &#x2705; | &#x2705; |
+| psalm-plugin-phpunit | [Psalm plugin for PHPUnit](https://github.com/psalm/psalm-plugin-phpunit) | &#x2705; | &#x2705; |
+| psalm-plugin-symfony | [Psalm Plugin for Symfony](https://github.com/psalm/psalm-plugin-symfony) | &#x2705; | &#x2705; |
+| psecio-parse | [Scans code for potential security-related issues](https://github.com/psecio/parse) | &#x2705; | &#x2705; |
+| rector | [Tool for instant code upgrades and refactoring](https://github.com/rectorphp/rector) | &#x2705; | &#x2705; |
+| roave-backward-compatibility-check | [Tool to compare two revisions of a class API to check for BC breaks](https://github.com/Roave/BackwardCompatibilityCheck) | &#x2705; | &#x274C; |
+| simple-phpunit | [Provides utilities to report legacy tests and usage of deprecated code](https://symfony.com/doc/current/components/phpunit_bridge.html) | &#x2705; | &#x2705; |
+| twig-lint | [Standalone twig linter](https://github.com/asm89/twig-lint) | &#x2705; | &#x2705; |
+| twigcs | [The missing checkstyle for twig!](https://github.com/friendsoftwig/twigcs) | &#x2705; | &#x2705; |
+| yaml-lint | [Compact command line utility for checking YAML file syntax](https://github.com/j13k/yaml-lint) | &#x2705; | &#x2705; |
 
 ### Removed tools
 
@@ -134,7 +133,7 @@ To exclude some tools from the listing multiple `--exclude-tag` options can be a
 The `--tag` option can be used to filter tools by tags.
 
 ```
-./toolbox list-tools --exclude-tag exclude-php:7.3 --exclude-tag foo --tag bar
+./toolbox list-tools --exclude-tag exclude-php:7.4 --exclude-tag foo --tag bar
 ```
 
 ### Install tools
@@ -172,7 +171,7 @@ To exclude some tools from the installation multiple `--exclude-tag` options can
 The `--tag` option can be used to filter tools by tags.
 
 ```
-./toolbox install --exclude-tag exclude-php:7.3 --exclude-tag foo --tag bar
+./toolbox install --exclude-tag exclude-php:7.4 --exclude-tag foo --tag bar
 ```
 
 ### Test if installed tools are usable
@@ -195,7 +194,7 @@ To exclude some tools from the generated test command multiple `--exclude-tag` o
 The `--tag` option can be used to filter tools by tags.
 
 ```
-./toolbox test --exclude-tag exclude-php:7.3 --exclude-tag foo --tag bar
+./toolbox test --exclude-tag exclude-php:7.4 --exclude-tag foo --tag bar
 ```
 
 ### Tools definitions
@@ -237,7 +236,7 @@ Tools can be tagged in order to enable grouping and filtering them.
 The tags below have a special meaning:
 
 * `pre-installation` - these tools will be installed before any other tools.
-* `exclude-php:7.3`, `exclude-php:7.1` etc - used to exclude installation on the specified php version.
+* `exclude-php:8.1`, `exclude-php:7.4` etc - used to exclude installation on the specified php version.
 
 ## Contributing
 

--- a/bin/devkit.php
+++ b/bin/devkit.php
@@ -73,17 +73,16 @@ $application->add(
             $readmePath = $input->getOption('readme');
             $tools = $this->loadTools($jsonPath);
 
-            $toolsList = '| Name | Description | PHP 7.3 | PHP 7.4 | PHP 8.0' . PHP_EOL;
+            $toolsList = '| Name | Description | PHP 7.4 | PHP 8.0' . PHP_EOL;
             $toolsList .= '| :--- | :---------- | :------ | :------ | :------' . PHP_EOL;
             $toolsList .= $tools->sort(function (Tool $left, Tool $right) {
                 return strcasecmp($left->name(), $right->name());
             })->reduce('', function ($acc, Tool $tool) {
 
-                return $acc . sprintf('| %s | [%s](%s) | %s | %s | %s |',
+                return $acc . sprintf('| %s | [%s](%s) | %s | %s |',
                         $tool->name(),
                         $tool->summary(),
                         $tool->website(),
-                        in_array('exclude-php:7.3', $tool->tags(), true) ? '&#x274C;' : '&#x2705;' ,
                         in_array('exclude-php:7.4', $tool->tags(), true) ? '&#x274C;' : '&#x2705;' ,
                         in_array('exclude-php:8.0', $tool->tags(), true) ? '&#x274C;' : '&#x2705;'
                     ) . PHP_EOL;

--- a/bin/devkit.php
+++ b/bin/devkit.php
@@ -74,7 +74,7 @@ $application->add(
             $tools = $this->loadTools($jsonPath);
 
             $toolsList = '| Name | Description | PHP 7.4 | PHP 8.0' . PHP_EOL;
-            $toolsList .= '| :--- | :---------- | :------ | :------ | :------' . PHP_EOL;
+            $toolsList .= '| :--- | :---------- | :------ | :------' . PHP_EOL;
             $toolsList .= $tools->sort(function (Tool $left, Tool $right) {
                 return strcasecmp($left->name(), $right->name());
             })->reduce('', function ($acc, Tool $tool) {

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Helps to discover and install tools",
     "type": "project",
     "require": {
-        "php": "^7.4 || ~8.0.0",
+        "php": "^7.4.7 || ~8.0.0",
         "symfony/console": "^4.4 || ^5.3",
         "psr/container": "^1.0"
     },
@@ -11,7 +11,7 @@
         "phpunit/phpunit": "^9.5",
         "zalas/phpunit-globals": "^2.1",
         "phpspec/prophecy-phpunit": "^2.0",
-        "infection/infection": "^0.18 || ^0.20.2"
+        "infection/infection": "^0.25.4"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Helps to discover and install tools",
     "type": "project",
     "require": {
-        "php": "^7.3 || ~8.0.0",
+        "php": "^7.4 || ~8.0.0",
         "symfony/console": "^4.4 || ^5.3",
         "psr/container": "^1.0"
     },

--- a/infection.json.dist
+++ b/infection.json.dist
@@ -12,6 +12,8 @@
         "@default": true,
         "IdenticalEqual": false,
         "NotIdenticalNotEqual": false,
+        "Concat": false,
+        "ConcatOperandRemoval": false,
         "ArrayItemRemoval": {
             "ignore": [
                 "Zalas\\Toolbox\\Cli\\Command\\ListCommand::execute"

--- a/resources/architecture.json
+++ b/resources/architecture.json
@@ -26,7 +26,7 @@
                 }
             },
             "test": "deptrac list",
-            "tags": ["featured", "architecture", "exclude-php:7.3"]
+            "tags": ["featured", "architecture"]
         },
         {
             "name": "pdepend",

--- a/resources/compatibility.json
+++ b/resources/compatibility.json
@@ -24,7 +24,7 @@
                 }
             },
             "test": "roave-backward-compatibility-check --version",
-            "tags": ["exclude-php:7.3", "exclude-php:8.0", "compatibility"]
+            "tags": ["exclude-php:8.0", "compatibility"]
         }
     ]
 }

--- a/resources/composer.json
+++ b/resources/composer.json
@@ -38,19 +38,7 @@
                 }
             },
             "test": "composer-require-checker -V",
-            "tags": ["exclude-php:7.3", "composer"]
-        },
-        {
-            "name": "composer-require-checker-v2",
-            "summary": "Verify that no unknown symbols are used in the sources of a package.",
-            "website": "https://github.com/maglnet/ComposerRequireChecker",
-            "command": {
-                "composer-global-install": {
-                    "package": "maglnet/composer-require-checker:^2.0"
-                }
-            },
-            "test": "composer-require-checker -V",
-            "tags": ["exclude-php:7.4", "exclude-php:8.0", "composer"]
+            "tags": ["composer"]
         }
     ]
 }

--- a/resources/linting.json
+++ b/resources/linting.json
@@ -24,7 +24,7 @@
                 }
             },
             "test": "phplint -V",
-            "tags": ["exclude-php:7.3", "linting"]
+            "tags": ["linting"]
         },
         {
             "name": "twig-lint",

--- a/resources/test.json
+++ b/resources/test.json
@@ -38,7 +38,7 @@
                 }
             },
             "test": "infection --version",
-            "tags": ["featured", "exclude-php:7.3", "test"]
+            "tags": ["featured", "test"]
         },
         {
             "name": "paratest",
@@ -79,7 +79,7 @@
                 }
             },
             "test": "php-fuzzer --help",
-            "tags": ["exclude-php:7.3", "test"]
+            "tags": ["test"]
         },
         {
             "name": "phpspec",


### PR DESCRIPTION
Support for PHP 7.3 has ended 6th December 2021.

Toolbox `v1.50.2` has the widest range of tools available for PHP 7.3. Since tool maintainers have already started dropping PHP 7.3, and any future Toolbox versions would only offer less tools.