### PR TITLE
feat: added phpstan/extension-installer in the list of PHPStan packages

### DIFF
--- a/resources/phpstan.json
+++ b/resources/phpstan.json
@@ -28,6 +28,19 @@
             "tags": ["phpstan"]
         },
         {
+            "name": "phpstan-extension-installer",
+            "summary": "Composer plugin for automatic installation of PHPStan extensions.",
+            "website": "https://github.com/phpstan/extension-installer",
+            "command": {
+                "composer-bin-plugin": {
+                    "package": "phpstan/extension-installer",
+                    "namespace": "phpstan"
+                }
+            },
+            "test": "composer global bin phpstan show phpstan/extension-installer",
+            "tags": ["phpstan"]
+        },
+        {
             "name": "phpstan-ergebnis-rules",
             "summary": "Additional rules for PHPstan",
             "website": "https://github.com/ergebnis/phpstan-rules",


### PR DESCRIPTION
hi @jakzal 

as requested in #421 , I've added the `phpstan/extension-installer` package to list of items that is to be installed in the toolbox

dGo