### PR TITLE
chore: updating version local-php-security-checker

### DIFF
--- a/resources/security.json
+++ b/resources/security.json
@@ -20,7 +20,7 @@
             "website": "https://github.com/fabpot/local-php-security-checker",
             "command": {
                 "file-download": {
-                    "url": "https://github.com/fabpot/local-php-security-checker/releases/download/v1.0.0/local-php-security-checker_1.0.0_linux_amd64",
+                    "url": "https://github.com/fabpot/local-php-security-checker/releases/download/v2.0.3/local-php-security-checker_2.0.3_linux_amd64",
                     "file": "%target-dir%/local-php-security-checker"
                 },
                 "sh": {


### PR DESCRIPTION
Hello @jakzal,

I would like to propose an update of the local-php-security-checker tool in order to support jUnit reports which are not implemented in version 1.0.0 (currently used by the tool).

Thank you.
Best regards,