### PR TITLE
add support for PHPUnit 9

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,9 @@ It has been extracted as a separate project to make maintenance easier and enabl
 | phpstan-strict-rules | [Extra strict and opinionated rules for PHPStan](https://github.com/phpstan/phpstan-strict-rules) | &#x2705; | &#x2705; | &#x2705; |
 | phpstan-symfony | [Symfony extension for PHPStan](https://github.com/phpstan/phpstan-symfony) | &#x2705; | &#x2705; | &#x2705; |
 | phpstan-webmozart-assert | [PHPStan extension for webmozart/assert](https://github.com/phpstan/phpstan-webmozart-assert) | &#x2705; | &#x2705; | &#x2705; |
-| phpunit | [The PHP testing framework](https://phpunit.de/) | &#x2705; | &#x2705; | &#x2705; |
+| phpunit | [The PHP testing framework](https://phpunit.de/) | &#x274C; | &#x2705; | &#x2705; |
 | phpunit-8 | [The PHP testing framework (8.x version)](https://phpunit.de/) | &#x2705; | &#x2705; | &#x2705; |
+| phpunit-9 | [The PHP testing framework (9.x version)](https://phpunit.de/) | &#x2705; | &#x2705; | &#x2705; |
 | pint | [Opinionated PHP code style fixer for Laravel](https://github.com/laravel/pint) | &#x2705; | &#x2705; | &#x2705; |
 | psalm | [Finds errors in PHP applications](https://psalm.dev/) | &#x2705; | &#x2705; | &#x2705; |
 | psalm-plugin-doctrine | [Stubs to let Psalm understand Doctrine better](https://github.com/weirdan/doctrine-psalm-plugin) | &#x2705; | &#x2705; | &#x2705; |

--- a/resources/test.json
+++ b/resources/test.json
@@ -106,7 +106,7 @@
                 }
             },
             "test": "phpunit --version",
-            "tags": ["featured", "test"]
+            "tags": ["exclude-php:8.0", "featured", "test"]
         },
         {
             "name": "phpunit-9",

--- a/resources/test.json
+++ b/resources/test.json
@@ -109,6 +109,20 @@
             "tags": ["featured", "test"]
         },
         {
+            "name": "phpunit-9",
+            "summary": "The PHP testing framework (9.x version)",
+            "website": "https://phpunit.de/",
+            "command": {
+                "phive-install": {
+                    "alias": "phpunit@^9.0",
+                    "bin": "%target-dir%/phpunit-9",
+                    "sig": "4AA394086372C20A"
+                }
+            },
+            "test": "phpunit --version",
+            "tags": ["test"]
+        },
+        {
             "name": "phpunit-8",
             "summary": "The PHP testing framework (8.x version)",
             "website": "https://phpunit.de/",


### PR DESCRIPTION
PHPUnit 10 has become the default...  
adding back PHPUnit 9 in the available packages

<!--
Please read the CONTRIBUTING.md to learn about contributing to this project.

Please also note that this project is released with a Contributor Code of Conduct.
By participating in this project you agree to abide by its terms.
The Code of Conduct can be found in CODE_OF_CONDUCT.md.
-->

