### PR TITLE
Add ekino/phpstan-banned-code

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ It has been extracted as a separate project to make maintenance easier and enabl
 | phpmnd | [Helps to detect magic numbers](https://github.com/povils/phpmnd) | &#x2705; | &#x2705; | &#x2705; |
 | phpspec | [SpecBDD Framework](http://www.phpspec.net/) | &#x2705; | &#x2705; | &#x274C; |
 | phpstan | [Static Analysis Tool](https://github.com/phpstan/phpstan) | &#x2705; | &#x2705; | &#x2705; |
+| phpstan-banned-code | [PHPStan rules for detecting calls to specific functions you don't want in your project](https://github.com/ekino/phpstan-banned-code) | &#x2705; | &#x2705; | &#x2705; |
 | phpstan-beberlei-assert | [PHPStan extension for beberlei/assert](https://github.com/phpstan/phpstan-beberlei-assert) | &#x2705; | &#x2705; | &#x2705; |
 | phpstan-deprecation-rules | [PHPStan rules for detecting deprecated code](https://github.com/phpstan/phpstan-deprecation-rules) | &#x2705; | &#x2705; | &#x2705; |
 | phpstan-doctrine | [Doctrine extensions for PHPStan](https://github.com/phpstan/phpstan-doctrine) | &#x2705; | &#x2705; | &#x2705; |

--- a/resources/phpstan.json
+++ b/resources/phpstan.json
@@ -170,6 +170,21 @@
             },
             "test": "composer global bin phpstan show ergebnis/phpstan-rules",
             "tags": ["phpstan"]
+        },
+        {
+            "name": "phpstan-banned-code",
+            "summary": "PHPStan rules for detecting calls to specific functions you don't want in your project",
+            "website": "https://github.com/ekino/phpstan-banned-code",
+            "command": {
+                "composer-bin-plugin": {
+                    "package": "ekino/phpstan-banned-code",
+                    "namespace": "phpstan"
+                }
+            },
+            "test": "composer global bin phpstan show ekino/phpstan-banned-code",
+            "tags": [
+                "phpstan"
+            ]
         }
     ]
 }


### PR DESCRIPTION
Hello, here is a small PR to add a PHPStan extension that I often use in my projects : 

| Name | Description | PHP 8.0 | PHP 8.1 | PHP 8.2 |
| :--- | :---------- | :------ | :------ | :------ |
| phpstan-banned-code | [PHPStan rules for detecting calls to specific functions you don't want in your project](https://github.com/ekino/phpstan-banned-code) | &#x2705; | &#x2705; | &#x2705; |
