### PR TITLE
Download phan phar directly instead of using phive

### DIFF
--- a/resources/tools.json
+++ b/resources/tools.json
@@ -19,10 +19,9 @@
       "summary": "Static Analysis Tool",
       "website": "https://github.com/phan/phan",
       "command": {
-        "phive-install": {
-          "alias": "phan",
-          "bin": "%target-dir%/phan",
-          "sig": "8101FB57DD8130F0"
+        "phar-download": {
+          "phar": "https://github.com/phan/phan/releases/latest/download/phan.phar",
+          "bin": "%target-dir%/phan"
         }
       },
       "test": "phan -v",


### PR DESCRIPTION
Phan key is missing which prevents it from being downloaded with phive.

<!--
Please read the CONTRIBUTING.md to learn about contributing to this project.

Please also note that this project is released with a Contributor Code of Conduct.
By participating in this project you agree to abide by its terms.
The Code of Conduct can be found in CODE_OF_CONDUCT.md.
-->

