### PR TITLE
Allow PHPUnit 12 to be installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,8 +78,9 @@ It has been extracted as a separate project to make maintenance easier and enabl
 | phpstan-strict-rules | [Extra strict and opinionated rules for PHPStan](https://github.com/phpstan/phpstan-strict-rules) | &#x2705; | &#x2705; | &#x2705; | &#x2705; |
 | phpstan-symfony | [Symfony extension for PHPStan](https://github.com/phpstan/phpstan-symfony) | &#x2705; | &#x2705; | &#x2705; | &#x2705; |
 | phpstan-webmozart-assert | [PHPStan extension for webmozart/assert](https://github.com/phpstan/phpstan-webmozart-assert) | &#x2705; | &#x2705; | &#x2705; | &#x2705; |
-| phpunit | [The PHP testing framework](https://phpunit.de/) | &#x274C; | &#x2705; | &#x2705; | &#x2705; |
+| phpunit | [The PHP testing framework](https://phpunit.de/) | &#x274C; | &#x274C; | &#x2705; | &#x2705; |
 | phpunit-10 | [The PHP testing framework (10.x version)](https://phpunit.de/) | &#x2705; | &#x2705; | &#x2705; | &#x2705; |
+| phpunit-11 | [The PHP testing framework (11.x version)](https://phpunit.de/) | &#x274C; | &#x2705; | &#x2705; | &#x2705; |
 | phpunit-8 | [The PHP testing framework (8.x version)](https://phpunit.de/) | &#x2705; | &#x2705; | &#x2705; | &#x2705; |
 | phpunit-9 | [The PHP testing framework (9.x version)](https://phpunit.de/) | &#x2705; | &#x2705; | &#x2705; | &#x2705; |
 | pint | [Opinionated PHP code style fixer for Laravel](https://github.com/laravel/pint) | &#x2705; | &#x2705; | &#x2705; | &#x2705; |

--- a/resources/test.json
+++ b/resources/test.json
@@ -124,7 +124,21 @@
                 }
             },
             "test": "phpunit --version",
-            "tags": ["featured", "test", "exclude-php:8.1"]
+            "tags": ["featured", "test", "exclude-php:8.1", "exclude-php:8.2"]
+        },
+        {
+            "name": "phpunit-11",
+            "summary": "The PHP testing framework (11.x version)",
+            "website": "https://phpunit.de/",
+            "command": {
+                "phive-install": {
+                    "alias": "phpunit@^11.0",
+                    "bin": "%target-dir%/phpunit-11",
+                    "sig": "4AA394086372C20A"
+                }
+            },
+            "test": "phpunit-11 --version",
+            "tags": ["test", "exclude-php:8.1"]
         },
         {
             "name": "phpunit-10",
@@ -137,7 +151,7 @@
                     "sig": "4AA394086372C20A"
                 }
             },
-            "test": "phpunit-9 --version",
+            "test": "phpunit-10 --version",
             "tags": ["test"]
         },
         {


### PR DESCRIPTION
* disable PHPUnit 12 on PHP 8.2
* make PHPUnit 11 available as phpunit-11

<!--
Please read the CONTRIBUTING.md to learn about contributing to this project.

Please also note that this project is released with a Contributor Code of Conduct.
By participating in this project you agree to abide by its terms.
The Code of Conduct can be found in CODE_OF_CONDUCT.md.
-->

