### PR TITLE
Remove pepakriz/phpstan-exception-rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,6 @@ It has been extracted as a separate project to make maintenance easier and enabl
 | phpstan-deprecation-rules | [PHPStan rules for detecting deprecated code](https://github.com/phpstan/phpstan-deprecation-rules) | &#x2705; | &#x2705; | &#x2705; |
 | phpstan-doctrine | [Doctrine extensions for PHPStan](https://github.com/phpstan/phpstan-doctrine) | &#x2705; | &#x2705; | &#x2705; |
 | phpstan-ergebnis-rules | [Additional rules for PHPstan](https://github.com/ergebnis/phpstan-rules) | &#x2705; | &#x2705; | &#x2705; |
-| phpstan-exception-rules | [PHPStan rules for checked and unchecked exceptions](https://github.com/pepakriz/phpstan-exception-rules) | &#x2705; | &#x2705; | &#x2705; |
 | phpstan-larastan | [Separate installation of phpstan for larastan](https://github.com/phpstan/phpstan) | &#x2705; | &#x2705; | &#x2705; |
 | phpstan-phpunit | [PHPUnit extensions and rules for PHPStan](https://github.com/phpstan/phpstan-phpunit) | &#x2705; | &#x2705; | &#x2705; |
 | phpstan-strict-rules | [Extra strict and opinionated rules for PHPStan](https://github.com/phpstan/phpstan-strict-rules) | &#x2705; | &#x2705; | &#x2705; |
@@ -113,6 +112,7 @@ It has been extracted as a separate project to make maintenance easier and enabl
 | phpcf | [Finds usage of deprecated features](http://wapmorgan.github.io/PhpCodeFixer/) |
 | phpda | [Generates dependency graphs](https://mamuz.github.io/PhpDependencyAnalysis/) |
 | phpdoc-to-typehint | [Automatically adds type hints and return types based on PHPDocs](https://github.com/dunglas/phpdoc-to-typehint) |
+| phpstan-exception-rules | [PHPStan rules for checked and unchecked exceptions](https://github.com/pepakriz/phpstan-exception-rules) |
 | phpstan-localheinz-rules | [Additional rules for PHPstan](https://github.com/localheinz/phpstan-rules) |
 | phpunit-5 | [The PHP testing framework (5.x version)](https://phpunit.de/) |
 | phpunit-7 | [The PHP testing framework (7.x version)](https://phpunit.de/) |

--- a/resources/phpstan.json
+++ b/resources/phpstan.json
@@ -119,19 +119,6 @@
             "tags": ["phpstan"]
         },
         {
-            "name": "phpstan-exception-rules",
-            "summary": "PHPStan rules for checked and unchecked exceptions",
-            "website": "https://github.com/pepakriz/phpstan-exception-rules",
-            "command": {
-                "composer-bin-plugin": {
-                    "package": "pepakriz/phpstan-exception-rules",
-                    "namespace": "phpstan"
-                }
-            },
-            "test": "composer global bin phpstan show pepakriz/phpstan-exception-rules",
-            "tags": ["phpstan"]
-        },
-        {
             "name": "phpat",
             "summary": "Easy to use architecture testing tool",
             "website": "https://github.com/carlosas/phpat",


### PR DESCRIPTION
The package is becoming obsolete (see https://github.com/pepakriz/phpstan-exception-rules/issues/148).

It seems to be the only phpstan extension we provide that does not support phpstan v2 (see https://github.com/jakzal/phpqa/issues/433).

<!--
Please read the CONTRIBUTING.md to learn about contributing to this project.

Please also note that this project is released with a Contributor Code of Conduct.
By participating in this project you agree to abide by its terms.
The Code of Conduct can be found in CODE_OF_CONDUCT.md.
-->

