### PR TITLE
Remove pest

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@ It has been extracted as a separate project to make maintenance easier and enabl
 | parallel-lint | [Checks PHP file syntax](https://github.com/php-parallel-lint/PHP-Parallel-Lint) | &#x2705; | &#x2705; | &#x2705; |
 | paratest | [Parallel testing for PHPUnit](https://github.com/paratestphp/paratest) | &#x2705; | &#x2705; | &#x2705; |
 | pdepend | [Static Analysis Tool](https://pdepend.org/) | &#x2705; | &#x2705; | &#x2705; |
-| pest | [The elegant PHP Testing Framework](https://github.com/pestphp/pest) | &#x2705; | &#x2705; | &#x2705; |
 | phan | [Static Analysis Tool](https://github.com/phan/phan) | &#x2705; | &#x2705; | &#x2705; |
 | phive | [PHAR Installation and Verification Environment](https://phar.io/) | &#x2705; | &#x2705; | &#x2705; |
 | php-cs-fixer | [PHP Coding Standards Fixer](http://cs.symfony.com/) | &#x2705; | &#x2705; | &#x2705; |
@@ -109,6 +108,7 @@ It has been extracted as a separate project to make maintenance easier and enabl
 | box-legacy | [Legacy version of box](https://box-project.github.io/box2/) |
 | design-pattern | [Detects design patterns](https://github.com/Halleck45/DesignPatternDetector) |
 | parallel-lint | [Checks PHP file syntax](https://github.com/JakubOnderka/PHP-Parallel-Lint) |
+| pest | [The elegant PHP Testing Framework](https://github.com/pestphp/pest) |
 | php-coupling-detector | [Detects code coupling issues](https://akeneo.github.io/php-coupling-detector/) |
 | php-formatter | [Custom coding standards fixer](https://github.com/mmoreram/php-formatter) |
 | phpcf | [Finds usage of deprecated features](http://wapmorgan.github.io/PhpCodeFixer/) |

--- a/resources/test.json
+++ b/resources/test.json
@@ -56,23 +56,6 @@
             "tags": ["test"]
         },
         {
-            "name": "pest",
-            "summary": "The elegant PHP Testing Framework",
-            "website": "https://github.com/pestphp/pest",
-            "command": {
-                "sh": {
-                  "command": "composer global bin pest config allow-plugins.pestphp/pest-plugin true"
-                },
-                "composer-bin-plugin": {
-                    "package": "pestphp/pest",
-                    "namespace": "pest",
-                    "links": {"%target-dir%/pest": "pest"}
-                }
-            },
-            "test": "pest --version",
-            "tags": ["test"]
-        },
-        {
             "name": "phpcov",
             "summary": "a command-line frontend for the PHP_CodeCoverage library",
             "website": "https://github.com/sebastianbergmann/phpcov",


### PR DESCRIPTION
The latest pest version assumes it is installed in the project and expects the tests directory to be present. It is impossible to run it as an external tool anymore.

Example failure when trying to use pest installed with the composer-bin plugin:

```
 Pest\Exceptions\FatalException

  The test directory [/home/runner/work/toolbox/toolbox/build/tools/.composer/vendor-bin/pest/tests/] does not exist.

  at build/tools/.composer/vendor-bin/pest/vendor/pestphp/pest/src/Bootstrappers/BootFiles.php:45
     41▕         $rootPath = TestSuite::getInstance()->rootPath;
     42▕         $testsPath = $rootPath.DIRECTORY_SEPARATOR.testDirectory();
     43▕
     44▕         if (! is_dir($testsPath)) {
  ➜  45▕             throw new FatalException(sprintf('The test directory [%s] does not exist.', $testsPath));
     46▕         }
     47▕
     48▕         foreach (self::STRUCTURE as $filename) {
     49▕             $filename = sprintf('%s%s%s', $testsPath, DIRECTORY_SEPARATOR, $filename);
```
