### PR TITLE
Jack is no longer a Symfony cli app and does not have the --help switch

### DIFF
--- a/resources/composer.json
+++ b/resources/composer.json
@@ -92,12 +92,12 @@
             "website": "https://github.com/rectorphp/jack",
             "command": {
                 "composer-bin-plugin": {
-                    "package": "rector/jack",
+                    "package": "rector/jack:0.4.0",
                     "namespace": "jack",
                     "links": {"%target-dir%/jack": "jack"}
                 }
             },
-            "test": "jack --version",
+            "test": "jack help",
             "tags": ["composer"]
         }
     ]


### PR DESCRIPTION
Lock jack to 0.4.0 until a command to show version or help is supported. Currently, there's no way to show help for the tool without it crashing.

```
Fatal error: Uncaught Jack202512\Entropy\Console\Exception\InvalidCommandException: Register at leats one command, so application can run in /tools/.composer/vendor-bin/jack/vendor/rector/jack/vendor/entropy/entropy/src/Console/CommandRegistry.php:24
Stack trace:
#0 /tools/.composer/vendor-bin/jack/vendor/rector/jack/vendor/entropy/entropy/src/Container/Container.php(48): Jack202512\Entropy\Console\CommandRegistry->__construct(Array)
#1 /tools/.composer/vendor-bin/jack/vendor/rector/jack/vendor/entropy/entropy/src/Container/Container.php(99): Jack202512\Entropy\Container\Container->{closure:Jack202512\Entropy\Container\Container::__construct():46}(Object(Jack202512\Entropy\Container\Container))
#2 /tools/.composer/vendor-bin/jack/vendor/rector/jack/vendor/entropy/entropy/src/Container/Container.php(161): Jack202512\Entropy\Container\Container->make('Jack202512\\Entr...')
#3 /tools/.composer/vendor-bin/jack/vendor/rector/jack/vendor/entropy/entropy/src/Container/Container.php(189): Jack202512\Entropy\Container\Container->resolveDependenciesFromParameterReflections(Object(ReflectionMethod), Array, 'Jack202512\\Entr...')
#4 /tools/.composer/vendor-bin/jack/vendor/rector/jack/vendor/entropy/entropy/src/Container/Container.php(106): Jack202512\Entropy\Container\Container->createInstanceFromReflection(Object(ReflectionClass))
#5 /tools/.composer/vendor-bin/jack/vendor/rector/jack/vendor/entropy/entropy/src/Container/Container.php(161): Jack202512\Entropy\Container\Container->make('Jack202512\\Entr...')
#6 /tools/.composer/vendor-bin/jack/vendor/rector/jack/vendor/entropy/entropy/src/Container/Container.php(189): Jack202512\Entropy\Container\Container->resolveDependenciesFromParameterReflections(Object(ReflectionMethod), Array, 'Jack202512\\Entr...')
#7 /tools/.composer/vendor-bin/jack/vendor/rector/jack/vendor/entropy/entropy/src/Container/Container.php(106): Jack202512\Entropy\Container\Container->createInstanceFromReflection(Object(ReflectionClass))
#8 /tools/.composer/vendor-bin/jack/vendor/rector/jack/bin/jack.php(29): Jack202512\Entropy\Container\Container->make('Jack202512\\Entr...')
#9 /tools/.composer/vendor-bin/jack/vendor/rector/jack/bin/jack(5): require('/tools/.compose...')
#10 /tools/.composer/vendor-bin/jack/vendor/bin/jack(119): include('/tools/.compose...')
#11 {main}
  thrown in /tools/.composer/vendor-bin/jack/vendor/rector/jack/vendor/entropy/entropy/src/Console/CommandRegistry.php on line 24
```

see https://github.com/rectorphp/jack/pull/33

