### PR TITLE
Include mago, a blazing fast linter, formatter, and static analyzer for PHP, written in Rust

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ It has been extracted as a separate project to make maintenance easier and enabl
 | larastan | [PHPStan extension for Laravel](https://github.com/nunomaduro/larastan) | &#x2705; | &#x2705; | &#x2705; |
 | lines | [CLI tool for quick metrics of PHP projects](https://github.com/tomasVotruba/lines) | &#x2705; | &#x2705; | &#x2705; |
 | local-php-security-checker | [Checks composer dependencies for known security vulnerabilities](https://github.com/fabpot/local-php-security-checker) | &#x2705; | &#x2705; | &#x2705; |
+| mago | [A blazing fast linter, formatter, and static analyzer for PHP, written in Rust](https://mago.carthage.software/) | &#x2705; | &#x2705; | &#x2705; |
 | parallel-lint | [Checks PHP file syntax](https://github.com/php-parallel-lint/PHP-Parallel-Lint) | &#x2705; | &#x2705; | &#x2705; |
 | paratest | [Parallel testing for PHPUnit](https://github.com/paratestphp/paratest) | &#x2705; | &#x2705; | &#x2705; |
 | pdepend | [Static Analysis Tool](https://pdepend.org/) | &#x2705; | &#x2705; | &#x2705; |

--- a/resources/tools.json
+++ b/resources/tools.json
@@ -108,6 +108,18 @@
         }
       },
       "test": "phpmnd -V"
+    },
+    {
+      "name": "mago",
+      "summary": "A blazing fast linter, formatter, and static analyzer for PHP, written in Rust",
+      "website": "https://mago.carthage.software/",
+      "command": {
+        "sh": {
+          "command": "MAGO_VERSION=$(curl -sLo /dev/null -w '%{url_effective}' https://github.com/carthage-software/mago/releases/latest | sed 's@.*/@@') && curl -Ls \"https://github.com/carthage-software/mago/releases/download/${MAGO_VERSION}/mago-${MAGO_VERSION}-$(uname -m)-unknown-linux-musl.tar.gz\" | tar xz -C /tmp && mv \"/tmp/mago-${MAGO_VERSION}-$(uname -m)-unknown-linux-musl/mago\" %target-dir%/mago && chmod +x %target-dir%/mago && rm -rf \"/tmp/mago-${MAGO_VERSION}-$(uname -m)-unknown-linux-musl\""
+        }
+      },
+      "test": "mago --version",
+      "tags": ["linting", "checkstyle"]
     }
   ]
 }


### PR DESCRIPTION
Fixes #569