### PR TITLE
Update devkit supported versions on composer install/update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,11 +6,11 @@ TOOLBOX_VERSION?=dev
 build: install test
 .PHONY: build
 
-install:
+install: update-devkit-php-versions
 	composer install
 .PHONY: install
 
-update:
+update: update-devkit-php-versions
 	composer update
 .PHONY: update
 
@@ -21,6 +21,12 @@ update-min:
 update-no-dev:
 	composer update --prefer-stable --no-dev
 .PHONY: update-no-dev
+
+update-devkit-php-versions:
+	@VERSIONS=$$(grep '"php":' composer.json | sed 's/.*"php": "//;s/".*//' | tr '|' ' ' | sed 's/[~^>=]*//g;s/  */ /g;s/^ //;s/ $$//' | grep -oE '[0-9]+\.[0-9]+' | sort -uV | awk '{printf "%s'\''%s'\''", (NR>1?", ":""), $$0}'); \
+	sed -i.bak '/updated with: make update-devkit-php-versions/s|\(.*$$versions\) = .*|\1 = ['"$$VERSIONS"']; // updated with: make update-devkit-php-versions|' bin/devkit.php && rm -f bin/devkit.php.bak
+	@echo "Done. Updated PHP versions in bin/devkit.php"
+.PHONY: update-devkit-php-versions
 
 test: vendor cs deptrac phpunit infection
 .PHONY: test

--- a/bin/devkit.php
+++ b/bin/devkit.php
@@ -70,7 +70,7 @@ $application->add(
             $readmePath = $input->getOption('readme');
             $tools = $this->loadTools($jsonPath);
 
-            $versions = ['8.3', '8.4', '8.5'];
+            $versions = ['8.3', '8.4', '8.5']; // updated with: make update-devkit-php-versions
 
             $toolsList = '| Name | Description | '. implode(' ', array_map(fn($v) => sprintf('PHP %s |', $v), $versions))  . PHP_EOL;
             $toolsList .= '| :--- | :---------- | '. implode(' ', array_fill(0, count($versions), ':------ |')) . PHP_EOL;


### PR DESCRIPTION
Alternative implementation for #574. This should bring the attention to devkit when php versions change in composer.

Replaces #536, #549, #574.

Fixes #535.

